### PR TITLE
feat: spy-themed progress bar during surveillance sweep

### DIFF
--- a/src/ghsnitch/api.py
+++ b/src/ghsnitch/api.py
@@ -82,15 +82,19 @@ def build_contributions_query(users, from_iso, to_iso):
     return "{ " + "".join(aliases) + " }"
 
 
-def fetch_contributions(users, years, github_url: str = DEFAULT_GITHUB_URL):
+def fetch_contributions(
+    users, years, github_url: str = DEFAULT_GITHUB_URL, on_progress=None
+):
     """Fetch contribution counts for all users across year ranges.
 
     Returns dict[username][label] = int.
+    on_progress, if provided, is called with (completed, total) after each year.
     """
     year_ranges = get_year_ranges(years)
+    total = len(year_ranges)
     result = {username: {} for username in users}
 
-    for label, from_iso, to_iso in year_ranges:
+    for completed, (label, from_iso, to_iso) in enumerate(year_ranges, start=1):
         query = build_contributions_query(users, from_iso, to_iso)
         data = make_github_graphql_request(query, github_url)
         response_data = data.get("data", {})
@@ -108,5 +112,8 @@ def fetch_contributions(users, years, github_url: str = DEFAULT_GITHUB_URL):
                     .get("totalContributions", 0)
                 )
                 result[username][label] = count
+
+        if on_progress is not None:
+            on_progress(completed, total)
 
     return result

--- a/src/ghsnitch/cli.py
+++ b/src/ghsnitch/cli.py
@@ -3,6 +3,7 @@ import sys
 
 import click
 import requests
+from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn
 
 from .api import (
     SECRET_GITHUB_TOKEN,
@@ -97,10 +98,28 @@ def gh_snitch(  # noqa: PLR0913
         return
 
     click.echo("🔍 Initiating surveillance sweep...")
-    click.echo(f"📡 Intercepting field reports for {len(operative_list)} operatives...")
+
+    num_years_total = num_years + 1  # current year + prior years
+    use_progress = sys.stdout.isatty()
+
+    progress = Progress(
+        TextColumn("[bold blue]📡 Sweeping field reports..."),
+        BarColumn(),
+        TaskProgressColumn(),
+        TextColumn("[dim]{task.completed}/{task.total} years"),
+        disable=not use_progress,
+    )
 
     try:
-        data = fetch_contributions(operative_list, num_years, operative_github_url)
+        with progress:
+            task = progress.add_task("sweep", total=num_years_total)
+
+            def on_progress(completed, total):  # noqa: ARG001
+                progress.update(task, completed=completed)
+
+            data = fetch_contributions(
+                operative_list, num_years, operative_github_url, on_progress
+            )
     except requests.exceptions.RequestException as e:
         click.echo(f"📡 Signal lost. Operative unreachable: {e}", err=True)
         sys.exit(1)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -143,6 +143,31 @@ def test_fetch_contributions_uses_enterprise_url(requests_mock):
     assert result["alice"][current_year] == 99
 
 
+def test_fetch_contributions_calls_on_progress(requests_mock):
+    requests_mock.post(
+        "https://api.github.com/graphql",
+        json={
+            "data": {
+                "user_alice": {
+                    "login": "alice",
+                    "contributionsCollection": {
+                        "contributionCalendar": {"totalContributions": 1}
+                    },
+                }
+            }
+        },
+    )
+
+    calls = []
+    with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
+        fetch_contributions(["alice"], 1, on_progress=lambda c, t: calls.append((c, t)))
+
+    # years=1 → 2 ranges (current + 1 prior), progress called once per range
+    assert len(calls) == 2
+    assert calls[0] == (1, 2)
+    assert calls[1] == (2, 2)
+
+
 def test_make_github_graphql_request_raises_on_http_error(requests_mock):
     requests_mock.post("https://api.github.com/graphql", status_code=401)
 


### PR DESCRIPTION
## Summary

Closes #4

Adds a `rich` progress bar that advances as each year-range request completes, so operatives know the sweep is underway rather than staring at a blank terminal.

```
🔍 Initiating surveillance sweep...
📡 Sweeping field reports... ━━━━━━━━━━━━━━━━━━━━  3/4 years
```

- Automatically disabled when stdout is not a TTY (CI, piped output)
- `rich` is already a dependency — no new packages added
- `fetch_contributions` gains an optional `on_progress(completed, total)` callback, keeping API and UI layers decoupled

## Test plan

- [ ] `test_fetch_contributions_calls_on_progress` — callback fired once per year range with correct `(completed, total)` values
- [ ] All 41 existing tests continue to pass
- [ ] Manual: run `uv run gh-snitch --users <user>` in a TTY and confirm bar appears and advances
- [ ] Manual: pipe output (`uv run gh-snitch --users <user> | cat`) and confirm no bar artefacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)