### PR TITLE
perf: parallelise GraphQL requests across year ranges

### DIFF
--- a/src/ghsnitch/api.py
+++ b/src/ghsnitch/api.py
@@ -1,4 +1,5 @@
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, datetime, timezone
 
 import requests
@@ -82,11 +83,19 @@ def build_contributions_query(users, from_iso, to_iso):
     return "{ " + "".join(aliases) + " }"
 
 
+def _fetch_year(users, label, from_iso, to_iso, github_url):
+    """Fetch contributions for all users for a single year range."""
+    query = build_contributions_query(users, from_iso, to_iso)
+    data = make_github_graphql_request(query, github_url)
+    return label, data.get("data", {})
+
+
 def fetch_contributions(
     users, years, github_url: str = DEFAULT_GITHUB_URL, on_progress=None
 ):
     """Fetch contribution counts for all users across year ranges.
 
+    Requests are dispatched concurrently — one per year range.
     Returns dict[username][label] = int.
     on_progress, if provided, is called with (completed, total) after each year.
     """
@@ -94,26 +103,29 @@ def fetch_contributions(
     total = len(year_ranges)
     result = {username: {} for username in users}
 
-    for completed, (label, from_iso, to_iso) in enumerate(year_ranges, start=1):
-        query = build_contributions_query(users, from_iso, to_iso)
-        data = make_github_graphql_request(query, github_url)
-        response_data = data.get("data", {})
+    with ThreadPoolExecutor() as executor:
+        futures = {
+            executor.submit(_fetch_year, users, label, from_iso, to_iso, github_url)
+            for label, from_iso, to_iso in year_ranges
+        }
 
-        for username in users:
-            alias = f"user_{username.replace('-', '_').replace('.', '_')}"
-            user_data = response_data.get(alias)
-            if user_data is None:
-                # User not found — return 0
-                result[username][label] = 0
-            else:
-                count = (
-                    user_data.get("contributionsCollection", {})
-                    .get("contributionCalendar", {})
-                    .get("totalContributions", 0)
-                )
-                result[username][label] = count
+        for completed, future in enumerate(as_completed(futures), start=1):
+            label, response_data = future.result()
 
-        if on_progress is not None:
-            on_progress(completed, total)
+            for username in users:
+                alias = f"user_{username.replace('-', '_').replace('.', '_')}"
+                user_data = response_data.get(alias)
+                if user_data is None:
+                    result[username][label] = 0
+                else:
+                    count = (
+                        user_data.get("contributionsCollection", {})
+                        .get("contributionCalendar", {})
+                        .get("totalContributions", 0)
+                    )
+                    result[username][label] = count
+
+            if on_progress is not None:
+                on_progress(completed, total)
 
     return result


### PR DESCRIPTION
## Summary

Closes #3

All year-range GraphQL requests are now dispatched concurrently via `ThreadPoolExecutor` + `as_completed`. For `--years 3` (4 requests) this reduces total fetch time from ~4× a single round-trip down to ~1×.

The `on_progress` callback (driving the progress bar) still fires once per completed future, so the bar advances naturally as results land rather than all at once at the end.

No new dependencies — `concurrent.futures` is stdlib.

## Test plan

- [ ] All 41 existing tests pass (including `test_fetch_contributions_calls_on_progress`)
- [ ] Manual: run with `--years 5` against github.com and confirm noticeably faster than before
- [ ] Errors from any individual request still surface (via `future.result()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)