### PR TITLE
feat: make ± rank-delta column opt-in via --rank-delta

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ make build
 | `--totals` | Add a Total column per operative and a Total footer row |
 | `--percent` | Annotate each cell with the operative's `(N%)` share of that year's total |
 | `--delta` | Show change since last snapshot instead of current-year count |
+| `--rank-delta` | Show a ± column with rank change since the last run |
 | `--reset-snapshot` | Clear the saved contribution snapshot and exit |
 | `--config` | Path to config file |
 | `--init-config` | Write default config and exit |

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -10,6 +10,7 @@
 | `--totals` | off | Add a `Total` column (per-operative sum across all years) and a `Total` footer row (per-year sum across all operatives) |
 | `--percent` | off | Annotate each contribution cell with the operative's `(N%)` share of that year's total; percentages are colour-graded in TTY mode |
 | `--delta` | off | Replace the current-year column with `Δ Today` showing the change since the last saved snapshot; green/red-coded |
+| `--rank-delta` | off | Show a `±` column after the rank column indicating each operative's rank change since the last run |
 | `--reset-snapshot` | off | Clear the saved contribution snapshot and exit |
 | `--no-trend` | off | Hide the Trend column |
 | `--show-config` | off | Print current config and exit |
@@ -45,6 +46,7 @@ years = 3
 # min_contributions = 10  # hide operatives below this threshold
 # totals = false           # show Total column and footer row
 # percent = false          # annotate cells with (N%) share of year total
+# rank_delta = false       # show ± rank-change column
 ```
 
-CLI flags `--users`, `--years`, `--github-url`, `--min-contributions`, `--totals`, and `--percent` always override config file values.
+CLI flags `--users`, `--years`, `--github-url`, `--min-contributions`, `--totals`, `--percent`, and `--rank-delta` always override config file values.

--- a/docs/manual/usage.md
+++ b/docs/manual/usage.md
@@ -78,6 +78,32 @@ You can also set this in your config file to apply it by default:
 min_contributions = 10
 ```
 
+## Rank Delta — Tracking Position Changes
+
+Show a `±` column indicating how each operative's rank has shifted since the last run:
+
+```bash
+gh-snitch --rank-delta
+```
+
+```
+#   ±    Operative     Trend    2025   2024   2023
+1   =    alice         +         412    380    310
+2   ↑1   bob           =         210    195    180
+3   ↓1   charlie       -         170    210    220
+```
+
+- `↑N` / `↓N` — moved up or down N positions
+- `=` — no change
+- `new` — operative not present in the previous run
+
+The column is hidden by default. Enable it permanently in your config:
+
+```toml
+[display]
+rank_delta = true
+```
+
 ## Delta Mode — Changes Since Last Run
 
 Every successful run saves a snapshot of contribution counts to `~/.cache/gh-snitch/snapshot.json`. Pass `--delta` on a subsequent run to replace the current-year column with the change since the previous snapshot:

--- a/src/ghsnitch/cli.py
+++ b/src/ghsnitch/cli.py
@@ -94,6 +94,12 @@ logger = logging.getLogger(__name__)
     default=False,
     help="Clear the saved contribution snapshot and exit.",
 )
+@click.option(
+    "--rank-delta",
+    is_flag=True,
+    default=False,
+    help="Show a ± column indicating rank change since the last run.",
+)
 @click.version_option(version=importlib.metadata.version("ghsnitch"))
 def gh_snitch(  # noqa: PLR0913
     config,
@@ -109,6 +115,7 @@ def gh_snitch(  # noqa: PLR0913
     percent,
     delta,
     reset_snapshot,
+    rank_delta,
 ):
     """Spy-themed GitHub contribution surveillance tool."""
     setup_logging()
@@ -160,6 +167,8 @@ def gh_snitch(  # noqa: PLR0913
         cfg["totals"] = True
     if percent:
         cfg["percent"] = True
+    if rank_delta:
+        cfg["rank_delta"] = True
 
     operative_list = cfg["users"]
     logger.info(
@@ -299,6 +308,10 @@ def gh_snitch(  # noqa: PLR0913
             delta_col = "Δ Today"
             # Rank deltas are not meaningful when showing contribution deltas
             rank_deltas = None
+
+    # Only show rank-delta column when explicitly requested.
+    if not cfg.get("rank_delta", False):
+        rank_deltas = None
 
     table = render_table(
         rows,

--- a/src/ghsnitch/config.py
+++ b/src/ghsnitch/config.py
@@ -34,6 +34,9 @@ years = 3
 
 # Annotate each cell with the operative's percentage share of that year's total.
 # percent = false
+
+# Show a ± column with each operative's rank change since the last run.
+# rank_delta = false
 """
 
 
@@ -54,6 +57,7 @@ def load_config(config_path=None):
         "min_contributions": 0,
         "totals": False,
         "percent": False,
+        "rank_delta": False,
     }
     logger.debug("loading config from %s", path)
 
@@ -93,6 +97,8 @@ def load_config(config_path=None):
         config["totals"] = bool(display["totals"])
     if "percent" in display:
         config["percent"] = bool(display["percent"])
+    if "rank_delta" in display:
+        config["rank_delta"] = bool(display["rank_delta"])
 
     logger.debug(
         "config loaded users=%s years=%s github_url=%s",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -548,3 +548,78 @@ def test_successful_run_saves_snapshot(runner, tmp_path, requests_mock):
     assert snap.exists()
     data = json.loads(snap.read_text())
     assert data["contributions"]["alice"] is not None
+
+
+def test_rank_delta_hidden_by_default(runner, tmp_path, requests_mock):
+    """± column must not appear on a normal run even when a prior snapshot exists."""
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        '[operatives]\nusers = ["alice"]\n[surveillance]\nyears = 0\n'
+    )
+    requests_mock.post("https://api.github.com/graphql", json=_GRAPHQL_RESPONSE)
+
+    from datetime import date
+
+    current_year = str(date.today().year)
+    snap = tmp_path / "snapshot.json"
+    snap.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-04T10:00:00+00:00",
+                "contributions": {"alice": {current_year: 10}},
+                "ranks": {"alice": 1},
+            }
+        )
+    )
+
+    with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
+        with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
+            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", snap):
+                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                    result = runner.invoke(
+                        gh_snitch,
+                        ["--config", str(config_file), "--no-update-check"],
+                    )
+
+    assert result.exit_code == 0
+    assert "±" not in result.output
+
+
+def test_rank_delta_shown_with_flag(runner, tmp_path, requests_mock):
+    """± column appears when --rank-delta is passed and a prior snapshot exists."""
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        '[operatives]\nusers = ["alice"]\n[surveillance]\nyears = 0\n'
+    )
+    requests_mock.post("https://api.github.com/graphql", json=_GRAPHQL_RESPONSE)
+
+    from datetime import date
+
+    current_year = str(date.today().year)
+    snap = tmp_path / "snapshot.json"
+    snap.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-04T10:00:00+00:00",
+                "contributions": {"alice": {current_year: 10}},
+                "ranks": {"alice": 1},
+            }
+        )
+    )
+
+    with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
+        with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
+            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", snap):
+                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                    result = runner.invoke(
+                        gh_snitch,
+                        [
+                            "--config",
+                            str(config_file),
+                            "--no-update-check",
+                            "--rank-delta",
+                        ],
+                    )
+
+    assert result.exit_code == 0
+    assert "±" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -160,7 +160,7 @@ wheels = [
 
 [[package]]
 name = "ghsnitch"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The `±` rank-delta column was shown on every run after the first because `rank_deltas` was always computed from the saved snapshot
- Added `--rank-delta` flag (default: off) to make it opt-in
- Also settable as `rank_delta = true` in the `[display]` section of the config file

## Test plan

- [ ] Run without `--rank-delta` after a prior snapshot exists — confirm `±` column is absent
- [ ] Run with `--rank-delta` after a prior snapshot exists — confirm `±` column appears
- [ ] Set `rank_delta = true` in config — confirm `±` column appears without the flag
- [ ] `make test` passes (129/129)
- [ ] `make lint` passes

Closes #49

https://claude.ai/code/session_019N4hwLKpAVybhXeK5puynK
EOF
)