### PR TITLE
Fix tie-aware rank movement deltas

### DIFF
--- a/src/ghsnitch/cli.py
+++ b/src/ghsnitch/cli.py
@@ -1,5 +1,6 @@
 import importlib.metadata
 import logging
+import math
 import sys
 import time
 
@@ -20,6 +21,79 @@ from .ui import render_table
 from .updater import check_for_update
 
 logger = logging.getLogger(__name__)
+
+
+def _compute_rank_metadata(rows, current_year_label):
+    """Return display ranks and tie-aware movement positions for the leaderboard.
+
+    Args:
+        rows: iterable of contribution rows with a ``username`` key
+        current_year_label: year label used to sort the leaderboard
+
+    Returns:
+        tuple[dict[str, int], dict[str, float]]: competition ranks for display
+        and average occupied positions for movement tracking
+    """
+    sorted_rows = sorted(
+        rows, key=lambda r: (-r.get(current_year_label, 0), r["username"])
+    )
+    ranks = {}
+    positions = {}
+    i = 0
+    while i < len(sorted_rows):
+        current_count = sorted_rows[i].get(current_year_label, 0)
+        group_end = i + 1
+        while (
+            group_end < len(sorted_rows)
+            and sorted_rows[group_end].get(current_year_label, 0) == current_count
+        ):
+            group_end += 1
+
+        competition_rank = i + 1
+        average_position = (competition_rank + group_end) / 2
+        for row in sorted_rows[i:group_end]:
+            username = row["username"]
+            ranks[username] = competition_rank
+            positions[username] = average_position
+
+        i = group_end
+    return ranks, positions
+
+
+def _get_snapshot_positions(snapshot, current_year_label):
+    """Return tie-aware movement positions for a previous snapshot if possible.
+
+    Newer snapshots persist explicit movement positions. Older snapshots can
+    still be upgraded in place by deriving tie-aware positions from their
+    contribution
+    counts for the current year. If that data is unavailable, fall back to the
+    legacy rank metadata so movement continues to work across year boundaries.
+    """
+    stored_positions = snapshot.get("positions", {})
+    if stored_positions:
+        return stored_positions
+
+    snapshot_contributions = snapshot.get("contributions", {})
+    if any(
+        current_year_label in year_data for year_data in snapshot_contributions.values()
+    ):
+        snapshot_rows = []
+        for username, year_data in snapshot_contributions.items():
+            row = {"username": username}
+            row.update(year_data)
+            snapshot_rows.append(row)
+        _, positions = _compute_rank_metadata(snapshot_rows, current_year_label)
+        return positions
+
+    return snapshot.get("ranks", {})
+
+
+def _movement_delta(previous_position, current_position):
+    """Return an integer movement delta from tie-aware position scores."""
+    raw_delta = previous_position - current_position
+    if raw_delta == 0:
+        return 0
+    return int(math.copysign(math.ceil(abs(raw_delta)), raw_delta))
 
 
 @click.command()
@@ -226,22 +300,9 @@ def gh_snitch(  # noqa: PLR0913
     # repeated --delta invocations compare against the same fixed point.
     prev_snapshot = load_snapshot()
 
-    # Compute current ranks (competition ranking, same sort order as render_table).
+    # Compute current rank metadata using the same sort order as render_table.
     current_year_label = year_labels[0]
-    sorted_for_ranks = sorted(
-        rows, key=lambda r: (-r.get(current_year_label, 0), r["username"])
-    )
-    current_ranks: dict[str, int] = {}
-    for i, row in enumerate(sorted_for_ranks):
-        if i == 0:
-            current_ranks[row["username"]] = 1
-        else:
-            prev_count = sorted_for_ranks[i - 1].get(current_year_label, 0)
-            curr_count = row.get(current_year_label, 0)
-            prev_rank = current_ranks[sorted_for_ranks[i - 1]["username"]]
-            current_ranks[row["username"]] = (
-                prev_rank if curr_count == prev_count else i + 1
-            )
+    current_ranks, current_positions = _compute_rank_metadata(rows, current_year_label)
 
     if not delta:
         save_snapshot(
@@ -250,19 +311,22 @@ def gh_snitch(  # noqa: PLR0913
                 for row in rows
             },
             ranks=current_ranks,
+            positions=current_positions,
         )
 
-    # Compute rank deltas if a previous run's ranks are available.
+    # Compute visible leaderboard movement from tie-aware position scores.
     rank_deltas = None
     if prev_snapshot is not None:
-        prev_ranks: dict[str, int] = prev_snapshot.get("ranks", {})
-        if prev_ranks:
+        prev_positions = _get_snapshot_positions(prev_snapshot, current_year_label)
+        if prev_positions:
             rank_deltas = {}
-            for username, curr_rank in current_ranks.items():
-                if username not in prev_ranks:
+            for username, curr_position in current_positions.items():
+                if username not in prev_positions:
                     rank_deltas[username] = None  # new operative
                 else:
-                    rank_deltas[username] = prev_ranks[username] - curr_rank
+                    rank_deltas[username] = _movement_delta(
+                        prev_positions[username], curr_position
+                    )
 
     threshold = cfg["min_contributions"]
     suppressed = 0

--- a/src/ghsnitch/snapshot.py
+++ b/src/ghsnitch/snapshot.py
@@ -23,12 +23,14 @@ def load_snapshot():
         return None
 
 
-def save_snapshot(contributions, ranks=None):
-    """Persist contributions (and optionally ranks) to the snapshot cache.
+def save_snapshot(contributions, ranks=None, positions=None):
+    """Persist contributions and optional leaderboard metadata to the cache.
 
     Args:
         contributions: dict[username, dict[year_label, int]]
         ranks: optional dict[username, int] mapping each operative to their rank
+        positions: optional dict[username, float | int] mapping each operative
+            to their tie-aware leaderboard movement position
     """
     try:
         CACHE_DIR.mkdir(parents=True, exist_ok=True)
@@ -38,6 +40,8 @@ def save_snapshot(contributions, ranks=None):
         }
         if ranks is not None:
             data["ranks"] = ranks
+        if positions is not None:
+            data["positions"] = positions
         _SNAPSHOT_FILE.write_text(json.dumps(data))
     except OSError as e:
         logger.warning("failed to save snapshot: %s", e)

--- a/src/ghsnitch/ui.py
+++ b/src/ghsnitch/ui.py
@@ -290,8 +290,9 @@ def render_table(
         delta_col: label of the column whose values are deltas (rendered with +/- and
             green/red colouring instead of percentile-based grading)
         rank_deltas: optional dict[username, int | None] mapping each operative to their
-            rank change since the previous run (positive = moved up, None = new
-            operative). When provided, a ± column is shown after the # column.
+            leaderboard movement since the previous run (positive = moved up,
+            None = new operative). When provided, a ± column is shown after the
+            # column.
     """
     if not rows:
         return "(no operatives configured)"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -548,3 +548,63 @@ def test_successful_run_saves_snapshot(runner, tmp_path, requests_mock):
     assert snap.exists()
     data = json.loads(snap.read_text())
     assert data["contributions"]["alice"] is not None
+    assert data["ranks"] == {"alice": 1}
+    assert data["positions"] == {"alice": 1}
+
+
+def test_rank_delta_marks_both_sides_when_tie_splits(runner, tmp_path):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        '[operatives]\nusers = ["alice", "bob", "carol"]\n'
+        "[surveillance]\nyears = 0\n"
+    )
+
+    from datetime import date
+
+    current_year = str(date.today().year)
+    snap = tmp_path / "snapshot.json"
+    snap.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-04T10:00:00+00:00",
+                "contributions": {
+                    "alice": {current_year: 70},
+                    "bob": {current_year: 64},
+                    "carol": {current_year: 64},
+                },
+                "ranks": {"alice": 1, "bob": 2, "carol": 2},
+            }
+        )
+    )
+
+    current_data = {
+        "alice": {current_year: 70},
+        "bob": {current_year: 65},
+        "carol": {current_year: 63},
+    }
+
+    with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
+        with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
+            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", snap):
+                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                    with patch(
+                        "ghsnitch.cli.fetch_contributions",
+                        return_value=(current_data, []),
+                    ):
+                        result = runner.invoke(
+                            gh_snitch,
+                            [
+                                "--config",
+                                str(config_file),
+                                "--no-update-check",
+                                "--no-trend",
+                            ],
+                        )
+
+    assert result.exit_code == 0
+    assert "alice" in result.output
+    assert "bob" in result.output
+    assert "carol" in result.output
+    assert "  1   =   alice" in result.output
+    assert "  2  +1   bob" in result.output
+    assert "  3  -1   carol" in result.output

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -72,9 +72,14 @@ def test_save_snapshot_persists_ranks(tmp_path):
         with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
             from ghsnitch.snapshot import save_snapshot
 
-            save_snapshot({"alice": {"2026": 100}}, ranks={"alice": 1})
+            save_snapshot(
+                {"alice": {"2026": 100}},
+                ranks={"alice": 1},
+                positions={"alice": 1},
+            )
     data = json.loads(snap.read_text())
     assert data["ranks"] == {"alice": 1}
+    assert data["positions"] == {"alice": 1}
 
 
 def test_save_snapshot_no_ranks_key_when_omitted(tmp_path):
@@ -86,6 +91,7 @@ def test_save_snapshot_no_ranks_key_when_omitted(tmp_path):
             save_snapshot({"alice": {"2026": 100}})
     data = json.loads(snap.read_text())
     assert "ranks" not in data
+    assert "positions" not in data
 
 
 def test_save_snapshot_silently_ignores_os_error(tmp_path):


### PR DESCRIPTION
## Summary
- compute ± movement using tie-aware leaderboard positions instead of raw competition ranks
- persist movement positions in snapshots while keeping backward compatibility with older snapshot data
- add regression coverage for the tie-split scenario and snapshot metadata

## Testing
- make lint
- make test
- PYTHONPATH=src .venv/bin/python -m pytest tests/test_cli.py tests/test_snapshot.py -q

Fixes #52