### PR TITLE
feat: add --period option for named time-window surveillance

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ make build
 |---|---|
 | `--users` | Comma-separated usernames (overrides config) |
 | `--years` | Number of prior years (overrides config) |
+| `--period` | Report on a specific window: `week`, `month`, or `year` (overrides `--years`) |
 | `--min-contributions` | Hide operatives below this contribution count |
 | `--totals` | Add a Total column per operative and a Total footer row |
 | `--percent` | Annotate each cell with the operative's `(N%)` share of that year's total |

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -5,6 +5,7 @@
 | `--config PATH` | `~/.config/gh-snitch/config.toml` | Path to TOML config file |
 | `--users TEXT` | (from config) | Comma-separated GitHub usernames to surveil |
 | `--years INTEGER` | (from config, default 3) | Number of prior complete years to include |
+| `--period TEXT` | (from config, default none) | Report on a named window instead of full years: `week` (Mon→today), `month` (1st→today), `year` (Jan 1→today). Overrides `--years`. |
 | `--github-url URL` | `https://github.com` | GitHub base URL — set to your GitHub Enterprise Server hostname |
 | `--min-contributions INTEGER` | `0` (show all) | Hide operatives with fewer than N contributions in the current year |
 | `--totals` | off | Add a `Total` column (per-operative sum across all years) and a `Total` footer row (per-year sum across all operatives) |
@@ -37,6 +38,7 @@ users = ["alice", "bob"]
 
 [surveillance]
 years = 3
+# period = "month"  # "week", "month", or "year" — overrides years when set
 
 [network]
 # github_url = "https://github.example.com"  # omit for github.com
@@ -47,4 +49,4 @@ years = 3
 # percent = false          # annotate cells with (N%) share of year total
 ```
 
-CLI flags `--users`, `--years`, `--github-url`, `--min-contributions`, `--totals`, and `--percent` always override config file values.
+CLI flags `--users`, `--years`, `--period`, `--github-url`, `--min-contributions`, `--totals`, and `--percent` always override config file values.

--- a/docs/manual/usage.md
+++ b/docs/manual/usage.md
@@ -24,6 +24,30 @@ Control how many prior years are included alongside the current year:
 gh-snitch --years 5
 ```
 
+## Reporting on a Specific Time Window
+
+Instead of fetching full calendar years, use `--period` to focus on a named window:
+
+```bash
+# Contributions since the start of this week (Monday)
+gh-snitch --users alice,bob --period week
+
+# Contributions this month
+gh-snitch --users alice,bob --period month
+
+# Contributions this year (Jan 1 → today)
+gh-snitch --users alice,bob --period year
+```
+
+When `--period` is set the table shows a single column labelled `This Week`, `This Month`, or `This Year` and the `--years` option is ignored. The Trend column is also suppressed (there is no prior period to compare against).
+
+You can set a default period in your config file:
+
+```toml
+[surveillance]
+period = "month"
+```
+
 ## Initial Setup
 
 ```bash

--- a/src/ghsnitch/api.py
+++ b/src/ghsnitch/api.py
@@ -2,7 +2,7 @@ import calendar
 import logging
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import requests
 
@@ -85,6 +85,40 @@ def get_year_ranges(years):
     return ranges
 
 
+VALID_PERIODS = ("week", "month", "year")
+
+
+def get_period_range(period: str) -> tuple[str, str, str]:
+    """Return a (label, from_iso, to_iso) tuple for a named time period.
+
+    Supported periods:
+      'week'  — Monday of the current ISO week → today
+      'month' — 1st of the current month → today
+      'year'  — January 1st of the current year → today
+    """
+    today = date.today()
+    to_dt = datetime(
+        today.year, today.month, today.day, 23, 59, 59, tzinfo=timezone.utc
+    )
+
+    if period == "week":
+        monday = today - timedelta(days=today.weekday())
+        from_dt = datetime(
+            monday.year, monday.month, monday.day, 0, 0, 0, tzinfo=timezone.utc
+        )
+        label = "This Week"
+    elif period == "month":
+        from_dt = datetime(today.year, today.month, 1, 0, 0, 0, tzinfo=timezone.utc)
+        label = "This Month"
+    elif period == "year":
+        from_dt = datetime(today.year, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        label = "This Year"
+    else:
+        raise ValueError(f"Unknown period '{period}'. Valid periods: {VALID_PERIODS}")
+
+    return label, from_dt.isoformat(), to_dt.isoformat()
+
+
 def build_contributions_query(users, from_iso, to_iso):
     """Build a GraphQL query with aliases for each user."""
     aliases = []
@@ -114,7 +148,7 @@ def _fetch_year(users, label, from_iso, to_iso, github_url):
 
 
 def fetch_contributions(
-    users, years, github_url: str = DEFAULT_GITHUB_URL, on_progress=None
+    users, years, github_url: str = DEFAULT_GITHUB_URL, on_progress=None, *, period=None
 ):
     """Fetch contribution counts for all users across year ranges.
 
@@ -123,8 +157,14 @@ def fetch_contributions(
     Usernames that could not be resolved on GitHub appear in the not_found set
     with zero contributions in the result dict.
     on_progress, if provided, is called with (completed, total) after each year.
+
+    When period is set (one of VALID_PERIODS), a single range is fetched for
+    that named window and the years argument is ignored.
     """
-    year_ranges = get_year_ranges(years)
+    if period is not None:
+        year_ranges = [get_period_range(period)]
+    else:
+        year_ranges = get_year_ranges(years)
     total = len(year_ranges)
     result = {username: {} for username in users}
     null_counts: dict[str, int] = {username: 0 for username in users}

--- a/src/ghsnitch/cli.py
+++ b/src/ghsnitch/cli.py
@@ -10,8 +10,10 @@ from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn
 
 from .api import (
     SECRET_GITHUB_TOKEN,
+    VALID_PERIODS,
     current_year_fraction,
     fetch_contributions,
+    get_period_range,
     get_year_ranges,
 )
 from .config import generate_default_config, load_config
@@ -110,6 +112,12 @@ def _movement_delta(previous_position, current_position):
     help="Number of prior years to include (in addition to current year).",
 )
 @click.option(
+    "--period",
+    default=None,
+    type=click.Choice(list(VALID_PERIODS), case_sensitive=False),
+    help="Report on a named window: week, month, or year. Overrides --years.",
+)
+@click.option(
     "--show-config",
     is_flag=True,
     default=False,
@@ -173,6 +181,7 @@ def gh_snitch(  # noqa: PLR0913
     config,
     users,
     years,
+    period,
     github_url,
     show_config,
     init_config,
@@ -187,10 +196,11 @@ def gh_snitch(  # noqa: PLR0913
     """Spy-themed GitHub contribution surveillance tool."""
     setup_logging()
     logger.info(
-        "gh-snitch started config=%s users=%s years=%s github_url=%s",
+        "gh-snitch started config=%s users=%s years=%s period=%s github_url=%s",
         config,
         users,
         years,
+        period,
         github_url,
     )
 
@@ -208,6 +218,7 @@ def gh_snitch(  # noqa: PLR0913
         cfg = load_config(config)
         click.echo(f"users = {cfg['users']}")
         click.echo(f"years = {cfg['years']}")
+        click.echo(f"period = {cfg['period']}")
         click.echo(f"github_url = {cfg['github_url']}")
         return
 
@@ -226,6 +237,8 @@ def gh_snitch(  # noqa: PLR0913
         cfg["users"] = [u.strip() for u in users.split(",") if u.strip()]
     if years is not None:
         cfg["years"] = years
+    if period is not None:
+        cfg["period"] = period.lower()
     if github_url is not None:
         cfg["github_url"] = github_url
     if min_contributions is not None:
@@ -236,10 +249,12 @@ def gh_snitch(  # noqa: PLR0913
         cfg["percent"] = True
 
     operative_list = cfg["users"]
+    active_period = cfg.get("period")
     logger.info(
-        "effective config operatives=%s years=%s github_url=%s",
+        "effective config operatives=%s years=%s period=%s github_url=%s",
         operative_list,
         cfg["years"],
+        active_period,
         cfg["github_url"],
     )
     num_years = cfg["years"]
@@ -254,28 +269,37 @@ def gh_snitch(  # noqa: PLR0913
 
     click.echo("🔍 Initiating surveillance sweep...")
 
-    num_years_total = num_years + 1  # current year + prior years
+    num_ranges = 1 if active_period else num_years + 1
     use_progress = sys.stdout.isatty()
 
     progress = Progress(
         TextColumn("[bold blue]📡 Sweeping field reports..."),
         BarColumn(),
         TaskProgressColumn(),
-        TextColumn("[dim]{task.completed}/{task.total} years"),
+        TextColumn("[dim]{task.completed}/{task.total} ranges"),
         disable=not use_progress,
     )
 
-    logger.info("sweep starting operatives=%s num_years=%d", operative_list, num_years)
+    logger.info(
+        "sweep starting operatives=%s num_ranges=%d period=%s",
+        operative_list,
+        num_ranges,
+        active_period,
+    )
     sweep_start = time.monotonic()
     try:
         with progress:
-            task = progress.add_task("sweep", total=num_years_total)
+            task = progress.add_task("sweep", total=num_ranges)
 
             def on_progress(completed, total):  # noqa: ARG001
                 progress.update(task, completed=completed)
 
             data, not_found = fetch_contributions(
-                operative_list, num_years, operative_github_url, on_progress
+                operative_list,
+                num_years,
+                operative_github_url,
+                on_progress,
+                period=active_period,
             )
     except requests.exceptions.RequestException as e:
         duration = time.monotonic() - sweep_start
@@ -286,7 +310,10 @@ def gh_snitch(  # noqa: PLR0913
     duration = time.monotonic() - sweep_start
     logger.info("sweep complete duration=%.3fs", duration)
 
-    year_ranges = get_year_ranges(num_years)
+    if active_period:
+        year_ranges = [get_period_range(active_period)]
+    else:
+        year_ranges = get_year_ranges(num_years)
     year_labels = [label for label, _, _ in year_ranges]
 
     rows = []

--- a/src/ghsnitch/config.py
+++ b/src/ghsnitch/config.py
@@ -19,6 +19,10 @@ users = []
 [surveillance]
 # Number of prior complete years to include (in addition to the current year)
 years = 3
+# Report on a specific time window instead of full years.
+# Valid values: "week" (Mon→today), "month" (1st→today), "year" (Jan 1→today).
+# When set, the 'years' option is ignored.
+# period = "month"
 
 [network]
 # GitHub base URL. Change this to target a GitHub Enterprise Server instance.
@@ -50,6 +54,7 @@ def load_config(config_path=None):
     config = {
         "users": [],
         "years": 3,
+        "period": None,
         "github_url": "https://github.com",
         "min_contributions": 0,
         "totals": False,
@@ -83,6 +88,8 @@ def load_config(config_path=None):
         config["users"] = operatives["users"]
     if "years" in surveillance:
         config["years"] = surveillance["years"]
+    if "period" in surveillance:
+        config["period"] = surveillance["period"]
     if "github_url" in network:
         config["github_url"] = network["github_url"]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,6 +8,7 @@ from ghsnitch.api import (
     build_contributions_query,
     current_year_fraction,
     fetch_contributions,
+    get_period_range,
     get_year_ranges,
     graphql_url_for,
     make_github_graphql_request,
@@ -34,6 +35,70 @@ def test_graphql_url_for_enterprise_trailing_slash():
         graphql_url_for("https://github.example.com/")
         == "https://github.example.com/api/graphql"
     )
+
+
+def test_get_period_range_month():
+    with patch("ghsnitch.api.date") as mock_date:
+        mock_date.today.return_value = date(2026, 4, 15)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        label, from_iso, to_iso = get_period_range("month")
+    assert label == "This Month"
+    from_dt = datetime.fromisoformat(from_iso)
+    to_dt = datetime.fromisoformat(to_iso)
+    assert from_dt.month == 4 and from_dt.day == 1
+    assert to_dt.month == 4 and to_dt.day == 15
+
+
+def test_get_period_range_week():
+    # 2026-04-15 is a Wednesday; Monday is 2026-04-13
+    with patch("ghsnitch.api.date") as mock_date:
+        mock_date.today.return_value = date(2026, 4, 15)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        label, from_iso, to_iso = get_period_range("week")
+    assert label == "This Week"
+    from_dt = datetime.fromisoformat(from_iso)
+    to_dt = datetime.fromisoformat(to_iso)
+    assert from_dt.day == 13  # Monday
+    assert to_dt.day == 15  # today
+
+
+def test_get_period_range_year():
+    with patch("ghsnitch.api.date") as mock_date:
+        mock_date.today.return_value = date(2026, 4, 15)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        label, from_iso, to_iso = get_period_range("year")
+    assert label == "This Year"
+    from_dt = datetime.fromisoformat(from_iso)
+    to_dt = datetime.fromisoformat(to_iso)
+    assert from_dt.month == 1 and from_dt.day == 1
+    assert to_dt.month == 4 and to_dt.day == 15
+
+
+def test_get_period_range_invalid():
+    with pytest.raises(ValueError, match="Unknown period"):
+        get_period_range("decade")
+
+
+def test_fetch_contributions_with_period(requests_mock):
+    requests_mock.post(
+        "https://api.github.com/graphql",
+        json={
+            "data": {
+                "user_alice": {
+                    "login": "alice",
+                    "contributionsCollection": {
+                        "contributionCalendar": {"totalContributions": 7}
+                    },
+                }
+            }
+        },
+    )
+
+    with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
+        result, not_found = fetch_contributions(["alice"], years=3, period="week")
+
+    assert result["alice"]["This Week"] == 7
+    assert not_found == set()
 
 
 def test_get_year_ranges_structure():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -608,3 +608,133 @@ def test_rank_delta_marks_both_sides_when_tie_splits(runner, tmp_path):
     assert "  1   =   alice" in result.output
     assert "  2  +1   bob" in result.output
     assert "  3  -1   carol" in result.output
+
+
+def test_period_week_renders_this_week_column(runner, tmp_path, requests_mock):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        '[operatives]\nusers = ["alice"]\n[surveillance]\nyears = 3\n'
+    )
+    requests_mock.post("https://api.github.com/graphql", json=_GRAPHQL_RESPONSE)
+
+    with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
+        with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
+            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", tmp_path / "snap.json"):
+                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                    result = runner.invoke(
+                        gh_snitch,
+                        [
+                            "--config",
+                            str(config_file),
+                            "--no-update-check",
+                            "--period",
+                            "week",
+                        ],
+                    )
+
+    assert result.exit_code == 0
+    assert "This Week" in result.output
+    assert "alice" in result.output
+
+
+def test_period_month_renders_this_month_column(runner, tmp_path, requests_mock):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        '[operatives]\nusers = ["alice"]\n[surveillance]\nyears = 3\n'
+    )
+    requests_mock.post("https://api.github.com/graphql", json=_GRAPHQL_RESPONSE)
+
+    with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
+        with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
+            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", tmp_path / "snap.json"):
+                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                    result = runner.invoke(
+                        gh_snitch,
+                        [
+                            "--config",
+                            str(config_file),
+                            "--no-update-check",
+                            "--period",
+                            "month",
+                        ],
+                    )
+
+    assert result.exit_code == 0
+    assert "This Month" in result.output
+    assert "alice" in result.output
+
+
+def test_period_year_renders_this_year_column(runner, tmp_path, requests_mock):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        '[operatives]\nusers = ["alice"]\n[surveillance]\nyears = 3\n'
+    )
+    requests_mock.post("https://api.github.com/graphql", json=_GRAPHQL_RESPONSE)
+
+    with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
+        with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
+            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", tmp_path / "snap.json"):
+                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                    result = runner.invoke(
+                        gh_snitch,
+                        [
+                            "--config",
+                            str(config_file),
+                            "--no-update-check",
+                            "--period",
+                            "year",
+                        ],
+                    )
+
+    assert result.exit_code == 0
+    assert "This Year" in result.output
+    assert "alice" in result.output
+
+
+def test_period_from_config_file(runner, tmp_path, requests_mock):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        '[operatives]\nusers = ["alice"]\n[surveillance]\nyears = 3\nperiod = "month"\n'
+    )
+    requests_mock.post("https://api.github.com/graphql", json=_GRAPHQL_RESPONSE)
+
+    with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
+        with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
+            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", tmp_path / "snap.json"):
+                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                    result = runner.invoke(
+                        gh_snitch,
+                        ["--config", str(config_file), "--no-update-check"],
+                    )
+
+    assert result.exit_code == 0
+    assert "This Month" in result.output
+
+
+def test_period_makes_single_api_call(runner, tmp_path, requests_mock):
+    """Period mode should issue exactly one GraphQL request (one range)."""
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        '[operatives]\nusers = ["alice"]\n[surveillance]\nyears = 5\n'
+    )
+    adapter = requests_mock.post(
+        "https://api.github.com/graphql", json=_GRAPHQL_RESPONSE
+    )
+
+    with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
+        with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
+            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", tmp_path / "snap.json"):
+                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                    result = runner.invoke(
+                        gh_snitch,
+                        [
+                            "--config",
+                            str(config_file),
+                            "--no-update-check",
+                            "--period",
+                            "week",
+                        ],
+                    )
+
+    assert result.exit_code == 0
+    assert adapter.call_count == 1  # one range, not six

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,6 +39,22 @@ def test_load_config_defaults_for_missing_keys(tmp_path):
     cfg = load_config(str(config_file))
     assert cfg["users"] == []
     assert cfg["years"] == 3
+    assert cfg["period"] is None
+
+
+def test_load_config_period(tmp_path):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text('[surveillance]\nyears = 2\nperiod = "month"\n')
+    cfg = load_config(str(config_file))
+    assert cfg["period"] == "month"
+    assert cfg["years"] == 2
+
+
+def test_load_config_period_defaults_to_none(tmp_path):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("[surveillance]\nyears = 1\n")
+    cfg = load_config(str(config_file))
+    assert cfg["period"] is None
 
 
 def test_generate_default_config_creates_dirs(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -160,7 +160,7 @@ wheels = [
 
 [[package]]
 name = "ghsnitch"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #54

## Summary

- Adds `--period` CLI flag accepting `week`, `month`, or `year`
- Renders a single column (`This Week` / `This Month` / `This Year`) instead of the multi-year grid; `--years` is ignored when `--period` is set
- `period` key supported in `[surveillance]` section of the TOML config
- Trend column suppressed automatically (no prior period to compare against — `ui.py` already handles single-column mode)

## Changes

| File | What changed |
|---|---|
| `src/ghsnitch/api.py` | New `get_period_range(period)` function + `VALID_PERIODS` constant; `fetch_contributions` accepts `period=` keyword arg |
| `src/ghsnitch/cli.py` | `--period` option wired through config merge and `fetch_contributions` call |
| `src/ghsnitch/config.py` | `period` key loaded from `[surveillance]`; config template updated |
| `README.md` | Options table updated |
| `docs/manual/options.md` | `--period` row added; config file example updated |
| `docs/manual/usage.md` | New "Reporting on a Specific Time Window" section |
| `tests/test_api.py` | Tests for `get_period_range` (all three periods + invalid) and `fetch_contributions` with `period=` |
| `tests/test_cli.py` | Integration tests for each period value, config-file period, and single-API-call assertion |
| `tests/test_config.py` | `period` default and load tests |

## Test plan

- [x] `make test` — 140 tests, all passing
- [x] `make lint` — clean (ruff + black)
- [ ] Manual smoke test: `gh-snitch --users <handle> --period week --no-update-check`
