### PR TITLE
feat: flexible time-period filtering (--period, --last-months, --last-weeks, --since/--until)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ make build
 |---|---|
 | `--users` | Comma-separated usernames (overrides config) |
 | `--years` | Number of prior years (overrides config) |
-| `--period` | Report on a specific window: `week`, `month`, or `year` (overrides `--years`) |
+| `--period` | Report on a named window: `week`, `month`, or `year` (overrides `--years`) |
+| `--last-months N` | Show last N calendar months as separate columns |
+| `--last-weeks N` | Show last N ISO weeks as separate columns |
+| `--since DATE` | Start of a custom date range (`YYYY-MM-DD`); end defaults to today |
+| `--until DATE` | End of a custom date range (`YYYY-MM-DD`); requires `--since` |
 | `--min-contributions` | Hide operatives below this contribution count |
 | `--totals` | Add a Total column per operative and a Total footer row |
 | `--percent` | Annotate each cell with the operative's `(N%)` share of that year's total |

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -6,6 +6,10 @@
 | `--users TEXT` | (from config) | Comma-separated GitHub usernames to surveil |
 | `--years INTEGER` | (from config, default 3) | Number of prior complete years to include |
 | `--period TEXT` | (from config, default none) | Report on a named window instead of full years: `week` (Mon→today), `month` (1st→today), `year` (Jan 1→today). Overrides `--years`. |
+| `--last-months INTEGER` | (from config, default none) | Show the last N calendar months as separate columns. Trend is suppressed. |
+| `--last-weeks INTEGER` | (from config, default none) | Show the last N ISO weeks as separate columns. Trend is suppressed. |
+| `--since DATE` | CLI only | Start of a custom date range (`YYYY-MM-DD`). End defaults to today. Produces a single column. |
+| `--until DATE` | CLI only | End of a custom date range (`YYYY-MM-DD`). Must be used with `--since`. |
 | `--github-url URL` | `https://github.com` | GitHub base URL — set to your GitHub Enterprise Server hostname |
 | `--min-contributions INTEGER` | `0` (show all) | Hide operatives with fewer than N contributions in the current year |
 | `--totals` | off | Add a `Total` column (per-operative sum across all years) and a `Total` footer row (per-year sum across all operatives) |
@@ -38,7 +42,9 @@ users = ["alice", "bob"]
 
 [surveillance]
 years = 3
-# period = "month"  # "week", "month", or "year" — overrides years when set
+# period = "month"      # "week", "month", or "year" — overrides years when set
+# last_months = 6       # last 6 calendar months as separate columns
+# last_weeks = 8        # last 8 ISO weeks as separate columns
 
 [network]
 # github_url = "https://github.example.com"  # omit for github.com
@@ -49,4 +55,4 @@ years = 3
 # percent = false          # annotate cells with (N%) share of year total
 ```
 
-CLI flags `--users`, `--years`, `--period`, `--github-url`, `--min-contributions`, `--totals`, and `--percent` always override config file values.
+CLI flags `--users`, `--years`, `--period`, `--last-months`, `--last-weeks`, `--github-url`, `--min-contributions`, `--totals`, and `--percent` always override config file values.  `--since` and `--until` are command-line only (they encode specific calendar dates and don't belong in a persistent config).

--- a/docs/manual/usage.md
+++ b/docs/manual/usage.md
@@ -48,6 +48,45 @@ You can set a default period in your config file:
 period = "month"
 ```
 
+## Rolling Monthly or Weekly Columns
+
+Use `--last-months N` or `--last-weeks N` to produce a multi-column view where each column is one calendar month or one ISO week:
+
+```bash
+# Last 6 calendar months as separate columns
+gh-snitch --users alice,bob --last-months 6
+
+# Last 8 ISO weeks as separate columns
+gh-snitch --users alice,bob --last-weeks 8
+```
+
+Month columns are labelled `Apr 2026`, `Mar 2026`, … most-recent first.
+Week columns are labelled `2026-W15`, `2026-W14`, … most-recent first.
+
+The current (partial) month or week is always the first column.  The Trend column is suppressed because month-to-month and week-to-week comparisons are not annualised.
+
+Set defaults in your config file:
+
+```toml
+[surveillance]
+last_months = 6
+last_weeks = 8
+```
+
+## Custom Date Range
+
+Use `--since` and optionally `--until` to query an arbitrary window:
+
+```bash
+# Q1 2025
+gh-snitch --users alice,bob --since 2025-01-01 --until 2025-03-31
+
+# Everything since a specific date up to today
+gh-snitch --users alice,bob --since 2025-06-01
+```
+
+The resulting table shows a single column labelled `2025-01-01–2025-03-31` (or `Since 2025-06-01` when no end date is given).  `--until` cannot be used without `--since`.
+
 ## Initial Setup
 
 ```bash

--- a/src/ghsnitch/api.py
+++ b/src/ghsnitch/api.py
@@ -147,8 +147,91 @@ def _fetch_year(users, label, from_iso, to_iso, github_url):
     return label, data.get("data", {})
 
 
+def get_rolling_month_ranges(n: int) -> list[tuple[str, str, str]]:
+    """Return the last n calendar months as (label, from_iso, to_iso) tuples.
+
+    Most recent month first.  The current (partial) month is entry 0; prior
+    complete months follow.  Labels use the format 'Apr 2026'.
+    """
+    today = date.today()
+    ranges = []
+    year, month = today.year, today.month
+    for i in range(n):
+        from_dt = datetime(year, month, 1, 0, 0, 0, tzinfo=timezone.utc)
+        if i == 0:
+            end_day = today.day
+        else:
+            end_day = calendar.monthrange(year, month)[1]
+        to_dt = datetime(year, month, end_day, 23, 59, 59, tzinfo=timezone.utc)
+        label = from_dt.strftime("%b %Y")
+        ranges.append((label, from_dt.isoformat(), to_dt.isoformat()))
+        month -= 1
+        if month == 0:
+            month = 12
+            year -= 1
+    return ranges
+
+
+def get_rolling_week_ranges(n: int) -> list[tuple[str, str, str]]:
+    """Return the last n ISO weeks as (label, from_iso, to_iso) tuples.
+
+    Most recent week first.  The current (partial) week is entry 0; prior
+    complete weeks (Mon–Sun) follow.  Labels use the format '2026-W15'.
+    """
+    today = date.today()
+    current_monday = today - timedelta(days=today.weekday())
+    ranges = []
+    for i in range(n):
+        monday = current_monday - timedelta(weeks=i)
+        week_end = today if i == 0 else monday + timedelta(days=6)
+        from_dt = datetime(
+            monday.year, monday.month, monday.day, 0, 0, 0, tzinfo=timezone.utc
+        )
+        to_dt = datetime(
+            week_end.year, week_end.month, week_end.day, 23, 59, 59, tzinfo=timezone.utc
+        )
+        iso_year, iso_week, _ = monday.isocalendar()
+        label = f"{iso_year}-W{iso_week:02d}"
+        ranges.append((label, from_dt.isoformat(), to_dt.isoformat()))
+    return ranges
+
+
+def get_custom_range(since: str, until: str | None = None) -> tuple[str, str, str]:
+    """Return a (label, from_iso, to_iso) for an arbitrary date range.
+
+    since and until are YYYY-MM-DD strings; until defaults to today.
+    Raises ValueError for invalid or out-of-order dates.
+    """
+    try:
+        from_date = date.fromisoformat(since)
+    except ValueError:
+        raise ValueError(f"Invalid date '{since}'. Expected YYYY-MM-DD.")
+    to_date = date.today()
+    if until is not None:
+        try:
+            to_date = date.fromisoformat(until)
+        except ValueError:
+            raise ValueError(f"Invalid date '{until}'. Expected YYYY-MM-DD.")
+    if from_date > to_date:
+        raise ValueError(f"--since ({since}) must not be after --until ({to_date}).")
+    from_dt = datetime(
+        from_date.year, from_date.month, from_date.day, 0, 0, 0, tzinfo=timezone.utc
+    )
+    to_dt = datetime(
+        to_date.year, to_date.month, to_date.day, 23, 59, 59, tzinfo=timezone.utc
+    )
+    label = f"{since}–{to_date.isoformat()}" if until else f"Since {since}"
+    return label, from_dt.isoformat(), to_dt.isoformat()
+
+
 def fetch_contributions(
-    users, years, github_url: str = DEFAULT_GITHUB_URL, on_progress=None, *, period=None
+    users,
+    years,
+    github_url: str = DEFAULT_GITHUB_URL,
+    on_progress=None,
+    *,
+    period=None,
+    year_ranges=None,
 ):
     """Fetch contribution counts for all users across year ranges.
 
@@ -158,21 +241,24 @@ def fetch_contributions(
     with zero contributions in the result dict.
     on_progress, if provided, is called with (completed, total) after each year.
 
-    When period is set (one of VALID_PERIODS), a single range is fetched for
-    that named window and the years argument is ignored.
+    year_ranges (explicit list of (label, from_iso, to_iso) tuples) takes
+    highest precedence.  When period is set, a single named-window range is
+    used.  Otherwise get_year_ranges(years) is called.
     """
-    if period is not None:
-        year_ranges = [get_period_range(period)]
+    if year_ranges is not None:
+        ranges = year_ranges
+    elif period is not None:
+        ranges = [get_period_range(period)]
     else:
-        year_ranges = get_year_ranges(years)
-    total = len(year_ranges)
+        ranges = get_year_ranges(years)
+    total = len(ranges)
     result = {username: {} for username in users}
     null_counts: dict[str, int] = {username: 0 for username in users}
 
     with ThreadPoolExecutor() as executor:
         futures = {
             executor.submit(_fetch_year, users, label, from_iso, to_iso, github_url)
-            for label, from_iso, to_iso in year_ranges
+            for label, from_iso, to_iso in ranges
         }
 
         for completed, future in enumerate(as_completed(futures), start=1):

--- a/src/ghsnitch/cli.py
+++ b/src/ghsnitch/cli.py
@@ -13,7 +13,10 @@ from .api import (
     VALID_PERIODS,
     current_year_fraction,
     fetch_contributions,
+    get_custom_range,
     get_period_range,
+    get_rolling_month_ranges,
+    get_rolling_week_ranges,
     get_year_ranges,
 )
 from .config import generate_default_config, load_config
@@ -118,6 +121,30 @@ def _movement_delta(previous_position, current_position):
     help="Report on a named window: week, month, or year. Overrides --years.",
 )
 @click.option(
+    "--last-months",
+    default=None,
+    type=int,
+    help="Show the last N calendar months as separate columns.",
+)
+@click.option(
+    "--last-weeks",
+    default=None,
+    type=int,
+    help="Show the last N ISO weeks as separate columns.",
+)
+@click.option(
+    "--since",
+    default=None,
+    metavar="DATE",
+    help="Start of a custom date range (YYYY-MM-DD). End defaults to today.",
+)
+@click.option(
+    "--until",
+    default=None,
+    metavar="DATE",
+    help="End of a custom date range (YYYY-MM-DD). Requires --since.",
+)
+@click.option(
     "--show-config",
     is_flag=True,
     default=False,
@@ -182,6 +209,10 @@ def gh_snitch(  # noqa: PLR0913
     users,
     years,
     period,
+    last_months,
+    last_weeks,
+    since,
+    until,
     github_url,
     show_config,
     init_config,
@@ -196,11 +227,16 @@ def gh_snitch(  # noqa: PLR0913
     """Spy-themed GitHub contribution surveillance tool."""
     setup_logging()
     logger.info(
-        "gh-snitch started config=%s users=%s years=%s period=%s github_url=%s",
+        "gh-snitch started config=%s users=%s years=%s period=%s "
+        "last_months=%s last_weeks=%s since=%s until=%s github_url=%s",
         config,
         users,
         years,
         period,
+        last_months,
+        last_weeks,
+        since,
+        until,
         github_url,
     )
 
@@ -219,6 +255,8 @@ def gh_snitch(  # noqa: PLR0913
         click.echo(f"users = {cfg['users']}")
         click.echo(f"years = {cfg['years']}")
         click.echo(f"period = {cfg['period']}")
+        click.echo(f"last_months = {cfg['last_months']}")
+        click.echo(f"last_weeks = {cfg['last_weeks']}")
         click.echo(f"github_url = {cfg['github_url']}")
         return
 
@@ -232,6 +270,11 @@ def gh_snitch(  # noqa: PLR0913
 
     cfg = load_config(config)
 
+    # Validate --since / --until before touching config.
+    if until is not None and since is None:
+        click.echo("⚠️  --until requires --since to be set.", err=True)
+        sys.exit(1)
+
     # Merge CLI overrides
     if users is not None:
         cfg["users"] = [u.strip() for u in users.split(",") if u.strip()]
@@ -239,6 +282,10 @@ def gh_snitch(  # noqa: PLR0913
         cfg["years"] = years
     if period is not None:
         cfg["period"] = period.lower()
+    if last_months is not None:
+        cfg["last_months"] = last_months
+    if last_weeks is not None:
+        cfg["last_weeks"] = last_weeks
     if github_url is not None:
         cfg["github_url"] = github_url
     if min_contributions is not None:
@@ -249,16 +296,22 @@ def gh_snitch(  # noqa: PLR0913
         cfg["percent"] = True
 
     operative_list = cfg["users"]
-    active_period = cfg.get("period")
-    logger.info(
-        "effective config operatives=%s years=%s period=%s github_url=%s",
-        operative_list,
-        cfg["years"],
-        active_period,
-        cfg["github_url"],
-    )
     num_years = cfg["years"]
+    active_period = cfg.get("period")
+    active_last_months = cfg.get("last_months")
+    active_last_weeks = cfg.get("last_weeks")
     operative_github_url = cfg["github_url"]
+
+    logger.info(
+        "effective config operatives=%s years=%s period=%s "
+        "last_months=%s last_weeks=%s github_url=%s",
+        operative_list,
+        num_years,
+        active_period,
+        active_last_months,
+        active_last_weeks,
+        operative_github_url,
+    )
 
     if not operative_list:
         click.echo(
@@ -267,9 +320,31 @@ def gh_snitch(  # noqa: PLR0913
         )
         return
 
+    # Resolve the active date ranges (highest-precedence wins).
+    # suppress_trend: True when the columns are not comparable year-over-year.
+    suppress_trend = False
+    if since is not None:
+        try:
+            active_year_ranges = [get_custom_range(since, until)]
+        except ValueError as e:
+            click.echo(f"⚠️  {e}", err=True)
+            sys.exit(1)
+        suppress_trend = True
+    elif active_last_months is not None:
+        active_year_ranges = get_rolling_month_ranges(active_last_months)
+        suppress_trend = True
+    elif active_last_weeks is not None:
+        active_year_ranges = get_rolling_week_ranges(active_last_weeks)
+        suppress_trend = True
+    elif active_period is not None:
+        active_year_ranges = [get_period_range(active_period)]
+        # trend suppressed implicitly by len < 2 in render_table
+    else:
+        active_year_ranges = get_year_ranges(num_years)
+
     click.echo("🔍 Initiating surveillance sweep...")
 
-    num_ranges = 1 if active_period else num_years + 1
+    num_ranges = len(active_year_ranges)
     use_progress = sys.stdout.isatty()
 
     progress = Progress(
@@ -281,10 +356,9 @@ def gh_snitch(  # noqa: PLR0913
     )
 
     logger.info(
-        "sweep starting operatives=%s num_ranges=%d period=%s",
+        "sweep starting operatives=%s num_ranges=%d",
         operative_list,
         num_ranges,
-        active_period,
     )
     sweep_start = time.monotonic()
     try:
@@ -299,7 +373,7 @@ def gh_snitch(  # noqa: PLR0913
                 num_years,
                 operative_github_url,
                 on_progress,
-                period=active_period,
+                year_ranges=active_year_ranges,
             )
     except requests.exceptions.RequestException as e:
         duration = time.monotonic() - sweep_start
@@ -310,11 +384,7 @@ def gh_snitch(  # noqa: PLR0913
     duration = time.monotonic() - sweep_start
     logger.info("sweep complete duration=%.3fs", duration)
 
-    if active_period:
-        year_ranges = [get_period_range(active_period)]
-    else:
-        year_ranges = get_year_ranges(num_years)
-    year_labels = [label for label, _, _ in year_ranges]
+    year_labels = [label for label, _, _ in active_year_ranges]
 
     rows = []
     for username, year_data in data.items():
@@ -395,7 +465,7 @@ def gh_snitch(  # noqa: PLR0913
         rows,
         year_labels,
         year_fraction=current_year_fraction(),
-        show_trend=not no_trend and delta_col is None,
+        show_trend=not no_trend and delta_col is None and not suppress_trend,
         show_totals=cfg.get("totals", False),
         show_percent=cfg.get("percent", False),
         delta_col=delta_col,

--- a/src/ghsnitch/config.py
+++ b/src/ghsnitch/config.py
@@ -19,10 +19,14 @@ users = []
 [surveillance]
 # Number of prior complete years to include (in addition to the current year)
 years = 3
-# Report on a specific time window instead of full years.
+# Report on a named window instead of full years.
 # Valid values: "week" (Mon→today), "month" (1st→today), "year" (Jan 1→today).
 # When set, the 'years' option is ignored.
 # period = "month"
+# Show the last N calendar months as separate columns.
+# last_months = 6
+# Show the last N ISO weeks as separate columns.
+# last_weeks = 8
 
 [network]
 # GitHub base URL. Change this to target a GitHub Enterprise Server instance.
@@ -55,6 +59,8 @@ def load_config(config_path=None):
         "users": [],
         "years": 3,
         "period": None,
+        "last_months": None,
+        "last_weeks": None,
         "github_url": "https://github.com",
         "min_contributions": 0,
         "totals": False,
@@ -90,6 +96,10 @@ def load_config(config_path=None):
         config["years"] = surveillance["years"]
     if "period" in surveillance:
         config["period"] = surveillance["period"]
+    if "last_months" in surveillance:
+        config["last_months"] = int(surveillance["last_months"])
+    if "last_weeks" in surveillance:
+        config["last_weeks"] = int(surveillance["last_weeks"])
     if "github_url" in network:
         config["github_url"] = network["github_url"]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,10 @@ from ghsnitch.api import (
     build_contributions_query,
     current_year_fraction,
     fetch_contributions,
+    get_custom_range,
     get_period_range,
+    get_rolling_month_ranges,
+    get_rolling_week_ranges,
     get_year_ranges,
     graphql_url_for,
     make_github_graphql_request,
@@ -77,6 +80,126 @@ def test_get_period_range_year():
 def test_get_period_range_invalid():
     with pytest.raises(ValueError, match="Unknown period"):
         get_period_range("decade")
+
+
+# --- get_rolling_month_ranges ---
+
+
+def test_get_rolling_month_ranges_count():
+    ranges = get_rolling_month_ranges(4)
+    assert len(ranges) == 4
+
+
+def test_get_rolling_month_ranges_labels_descending():
+    with patch("ghsnitch.api.date") as mock_date:
+        mock_date.today.return_value = date(2026, 4, 15)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        ranges = get_rolling_month_ranges(3)
+    labels = [r[0] for r in ranges]
+    assert labels == ["Apr 2026", "Mar 2026", "Feb 2026"]
+
+
+def test_get_rolling_month_ranges_current_month_ends_today():
+    with patch("ghsnitch.api.date") as mock_date:
+        mock_date.today.return_value = date(2026, 4, 15)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        ranges = get_rolling_month_ranges(1)
+    _, _, to_iso = ranges[0]
+    to_dt = datetime.fromisoformat(to_iso)
+    assert to_dt.day == 15
+
+
+def test_get_rolling_month_ranges_prior_month_ends_on_last_day():
+    with patch("ghsnitch.api.date") as mock_date:
+        mock_date.today.return_value = date(2026, 4, 15)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        ranges = get_rolling_month_ranges(2)
+    _, _, to_iso = ranges[1]  # March
+    to_dt = datetime.fromisoformat(to_iso)
+    assert to_dt.day == 31  # March has 31 days
+
+
+def test_get_rolling_month_ranges_crosses_year_boundary():
+    with patch("ghsnitch.api.date") as mock_date:
+        mock_date.today.return_value = date(2026, 2, 10)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        ranges = get_rolling_month_ranges(3)
+    labels = [r[0] for r in ranges]
+    assert labels == ["Feb 2026", "Jan 2026", "Dec 2025"]
+
+
+# --- get_rolling_week_ranges ---
+
+
+def test_get_rolling_week_ranges_count():
+    ranges = get_rolling_week_ranges(5)
+    assert len(ranges) == 5
+
+
+def test_get_rolling_week_ranges_labels_descending():
+    # 2026-04-15 is Wednesday; date(2026, 4, 15).isocalendar() == (2026, 16, 3)
+    with patch("ghsnitch.api.date") as mock_date:
+        mock_date.today.return_value = date(2026, 4, 15)
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        ranges = get_rolling_week_ranges(3)
+    labels = [r[0] for r in ranges]
+    assert labels == ["2026-W16", "2026-W15", "2026-W14"]
+
+
+def test_get_rolling_week_ranges_current_week_ends_today():
+    with patch("ghsnitch.api.date") as mock_date:
+        mock_date.today.return_value = date(2026, 4, 15)  # Wednesday
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        ranges = get_rolling_week_ranges(1)
+    _, _, to_iso = ranges[0]
+    to_dt = datetime.fromisoformat(to_iso)
+    assert to_dt.day == 15
+
+
+def test_get_rolling_week_ranges_prior_week_ends_sunday():
+    with patch("ghsnitch.api.date") as mock_date:
+        mock_date.today.return_value = date(2026, 4, 15)  # Wed W15
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)
+        ranges = get_rolling_week_ranges(2)
+    _, _, to_iso = ranges[1]  # prior week W14
+    to_dt = datetime.fromisoformat(to_iso)
+    assert to_dt.weekday() == 6  # Sunday
+
+
+# --- get_custom_range ---
+
+
+def test_get_custom_range_since_only():
+    from datetime import timezone as tz
+
+    today = date.today()
+    label, from_iso, to_iso = get_custom_range("2025-01-01")
+    assert label == "Since 2025-01-01"
+    expected = datetime(2025, 1, 1, 0, 0, 0, tzinfo=tz.utc)
+    assert datetime.fromisoformat(from_iso) == expected
+    assert datetime.fromisoformat(to_iso).date() == today
+
+
+def test_get_custom_range_since_and_until():
+    label, from_iso, to_iso = get_custom_range("2025-01-01", "2025-03-31")
+    assert label == "2025-01-01–2025-03-31"
+    assert datetime.fromisoformat(from_iso).month == 1
+    assert datetime.fromisoformat(to_iso).month == 3
+
+
+def test_get_custom_range_invalid_since():
+    with pytest.raises(ValueError, match="Invalid date"):
+        get_custom_range("not-a-date")
+
+
+def test_get_custom_range_invalid_until():
+    with pytest.raises(ValueError, match="Invalid date"):
+        get_custom_range("2025-01-01", "bad")
+
+
+def test_get_custom_range_since_after_until():
+    with pytest.raises(ValueError, match="must not be after"):
+        get_custom_range("2025-06-01", "2025-01-01")
 
 
 def test_fetch_contributions_with_period(requests_mock):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -738,3 +738,128 @@ def test_period_makes_single_api_call(runner, tmp_path, requests_mock):
 
     assert result.exit_code == 0
     assert adapter.call_count == 1  # one range, not six
+
+
+# ---------------------------------------------------------------------------
+# --last-months / --last-weeks / --since / --until
+# ---------------------------------------------------------------------------
+
+
+def _make_config(tmp_path, years=0):
+    f = tmp_path / "config.toml"
+    f.write_text(f'[operatives]\nusers = ["alice"]\n[surveillance]\nyears = {years}\n')
+    return f
+
+
+def _run(runner, config_file, tmp_path, extra_args):
+    with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
+        with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
+            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", tmp_path / "snap.json"):
+                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                    base = ["--config", str(config_file), "--no-update-check"]
+                    return runner.invoke(gh_snitch, base + extra_args)
+
+
+def test_last_months_renders_month_columns(runner, tmp_path, requests_mock):
+    requests_mock.post("https://api.github.com/graphql", json=_GRAPHQL_RESPONSE)
+    cfg = _make_config(tmp_path)
+    result = _run(runner, cfg, tmp_path, ["--last-months", "3"])
+    assert result.exit_code == 0
+    # Three month columns should appear (e.g. "Apr 2026", "Mar 2026", "Feb 2026")
+    assert result.output.count("20") >= 3  # at least 3 year-suffixed labels
+
+
+def test_last_months_makes_n_api_calls(runner, tmp_path, requests_mock):
+    adapter = requests_mock.post(
+        "https://api.github.com/graphql", json=_GRAPHQL_RESPONSE
+    )
+    cfg = _make_config(tmp_path)
+    result = _run(runner, cfg, tmp_path, ["--last-months", "4"])
+    assert result.exit_code == 0
+    assert adapter.call_count == 4
+
+
+def test_last_weeks_renders_week_columns(runner, tmp_path, requests_mock):
+    requests_mock.post("https://api.github.com/graphql", json=_GRAPHQL_RESPONSE)
+    cfg = _make_config(tmp_path)
+    result = _run(runner, cfg, tmp_path, ["--last-weeks", "3"])
+    assert result.exit_code == 0
+    # ISO week labels look like "2026-W15"
+    assert "-W" in result.output
+
+
+def test_last_weeks_makes_n_api_calls(runner, tmp_path, requests_mock):
+    adapter = requests_mock.post(
+        "https://api.github.com/graphql", json=_GRAPHQL_RESPONSE
+    )
+    cfg = _make_config(tmp_path)
+    result = _run(runner, cfg, tmp_path, ["--last-weeks", "5"])
+    assert result.exit_code == 0
+    assert adapter.call_count == 5
+
+
+def test_since_renders_custom_label(runner, tmp_path, requests_mock):
+    requests_mock.post("https://api.github.com/graphql", json=_GRAPHQL_RESPONSE)
+    cfg = _make_config(tmp_path)
+    result = _run(runner, cfg, tmp_path, ["--since", "2025-01-01"])
+    assert result.exit_code == 0
+    assert "Since 2025-01-01" in result.output
+
+
+def test_since_and_until_renders_range_label(runner, tmp_path, requests_mock):
+    requests_mock.post("https://api.github.com/graphql", json=_GRAPHQL_RESPONSE)
+    cfg = _make_config(tmp_path)
+    result = _run(
+        runner, cfg, tmp_path, ["--since", "2025-01-01", "--until", "2025-03-31"]
+    )
+    assert result.exit_code == 0
+    assert "2025-01-01" in result.output
+    assert "2025-03-31" in result.output
+
+
+def test_until_without_since_exits_nonzero(runner, tmp_path):
+    cfg = _make_config(tmp_path)
+    with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
+        result = runner.invoke(
+            gh_snitch,
+            ["--config", str(cfg), "--no-update-check", "--until", "2025-03-31"],
+        )
+    assert result.exit_code != 0
+    assert "--until requires --since" in result.output
+
+
+def test_since_invalid_date_exits_nonzero(runner, tmp_path):
+    cfg = _make_config(tmp_path)
+    with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
+        with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
+            result = runner.invoke(
+                gh_snitch,
+                ["--config", str(cfg), "--no-update-check", "--since", "not-a-date"],
+            )
+    assert result.exit_code != 0
+
+
+def test_last_months_from_config(runner, tmp_path, requests_mock):
+    requests_mock.post("https://api.github.com/graphql", json=_GRAPHQL_RESPONSE)
+    cfg = tmp_path / "config.toml"
+    cfg.write_text(
+        '[operatives]\nusers = ["alice"]\n[surveillance]\nyears = 3\nlast_months = 2\n'
+    )
+    result = _run(runner, cfg, tmp_path, [])
+    assert result.exit_code == 0
+    # Two month columns → two API calls
+    # (just check it ran without error and has month-style labels)
+    assert result.output  # non-empty
+
+
+def test_last_weeks_from_config(runner, tmp_path, requests_mock):
+    adapter = requests_mock.post(
+        "https://api.github.com/graphql", json=_GRAPHQL_RESPONSE
+    )
+    cfg = tmp_path / "config.toml"
+    cfg.write_text(
+        '[operatives]\nusers = ["alice"]\n[surveillance]\nyears = 3\nlast_weeks = 3\n'
+    )
+    result = _run(runner, cfg, tmp_path, [])
+    assert result.exit_code == 0
+    assert adapter.call_count == 3

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -57,6 +57,28 @@ def test_load_config_period_defaults_to_none(tmp_path):
     assert cfg["period"] is None
 
 
+def test_load_config_last_months(tmp_path):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("[surveillance]\nlast_months = 6\n")
+    cfg = load_config(str(config_file))
+    assert cfg["last_months"] == 6
+
+
+def test_load_config_last_weeks(tmp_path):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("[surveillance]\nlast_weeks = 8\n")
+    cfg = load_config(str(config_file))
+    assert cfg["last_weeks"] == 8
+
+
+def test_load_config_last_months_defaults_to_none(tmp_path):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("[surveillance]\nyears = 1\n")
+    cfg = load_config(str(config_file))
+    assert cfg["last_months"] is None
+    assert cfg["last_weeks"] is None
+
+
 def test_generate_default_config_creates_dirs(tmp_path):
     path = tmp_path / "nested" / "dir" / "config.toml"
     result = generate_default_config(str(path))


### PR DESCRIPTION
Closes #54

## Summary

- Adds `--period week|month|year` for quick named-window surveillance (single column)
- Adds `--last-months N` and `--last-weeks N` for rolling multi-column views
- Adds `--since DATE` / `--until DATE` for arbitrary date ranges
- All new modes supported in the TOML config file (`[surveillance]`)
- Trend column suppressed where year-over-year comparison is meaningless

## New options

| Flag | Columns | Example label(s) |
|---|---|---|
| `--period week` | 1 | `This Week` |
| `--period month` | 1 | `This Month` |
| `--period year` | 1 | `This Year` |
| `--last-months 6` | 6 | `Apr 2026`, `Mar 2026`, … |
| `--last-weeks 8` | 8 | `2026-W16`, `2026-W15`, … |
| `--since 2025-01-01` | 1 | `Since 2025-01-01` |
| `--since 2025-01-01 --until 2025-03-31` | 1 | `2025-01-01–2025-03-31` |

**Precedence** (first match wins): `--since` › `--last-months` › `--last-weeks` › `--period` › `--years`

## Config file

```toml
[surveillance]
# period = "month"
# last_months = 6
# last_weeks = 8
```

`--since`/`--until` are command-line only (they encode specific calendar dates).

## Changes

| File | What changed |
|---|---|
| `src/ghsnitch/api.py` | `get_rolling_month_ranges`, `get_rolling_week_ranges`, `get_custom_range`; `fetch_contributions` accepts `year_ranges=` kwarg |
| `src/ghsnitch/cli.py` | Four new options; range-dispatch with precedence; `suppress_trend` flag |
| `src/ghsnitch/config.py` | `last_months`, `last_weeks` defaults + loading; template updated |
| `README.md` | Options table updated |
| `docs/manual/options.md` | New option rows; config example updated |
| `docs/manual/usage.md` | New sections for rolling and custom ranges |
| `tests/test_api.py` | Tests for all three new range generators |
| `tests/test_cli.py` | Integration tests for each new flag, config loading, and API call counts |
| `tests/test_config.py` | `last_months`/`last_weeks` load and default tests |

## Test plan

- [x] `make test` — 167 tests, all passing
- [x] `make lint` — clean
- [ ] Manual smoke: `gh-snitch --users <handle> --last-months 3 --no-update-check`
- [ ] Manual smoke: `gh-snitch --users <handle> --since 2025-01-01 --until 2025-06-30 --no-update-check`
