### PR TITLE
Add --team flag to select pre-defined user groups from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ make build
 | Flag | Description |
 |---|---|
 | `--users` | Comma-separated usernames (overrides config) |
+| `--team` | Select a named team from config (see `[teams.*]` in config file); overridden by `--users` |
 | `--years` | Number of prior years (overrides config) |
 | `--period` | Report on a named window: `week`, `month`, or `year` (overrides `--years`) |
 | `--last-months N` | Show last N calendar months as separate columns |

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -4,6 +4,7 @@
 |---|---|---|
 | `--config PATH` | `~/.config/gh-snitch/config.toml` | Path to TOML config file |
 | `--users TEXT` | (from config) | Comma-separated GitHub usernames to surveil |
+| `--team TEXT` | (from config) | Select a named team defined under `[teams.<name>]`. Overridden by `--users`. |
 | `--years INTEGER` | (from config, default 3) | Number of prior complete years to include |
 | `--period TEXT` | (from config, default none) | Report on a named window instead of full years: `week` (Mon→today), `month` (1st→today), `year` (Jan 1→today). Overrides `--years`. |
 | `--last-months INTEGER` | (from config, default none) | Show the last N calendar months as separate columns. Trend is suppressed. |
@@ -57,6 +58,13 @@ years = 3
 # min_contributions = 10  # hide operatives below this threshold
 # totals = false           # show Total column and footer row
 # percent = false          # annotate cells with (N%) share of year total
+
+# Named teams — select one at runtime with --team <name>
+[teams.platform]
+users = ["alice", "bob"]
+
+[teams.backend]
+users = ["carol", "dave"]
 ```
 
-CLI flags `--users`, `--years`, `--period`, `--last-months`, `--last-weeks`, `--format`, `--github-url`, `--min-contributions`, `--totals`, and `--percent` always override config file values.  `--since` and `--until` are command-line only (they encode specific calendar dates and don't belong in a persistent config).
+CLI flags `--users`, `--team`, `--years`, `--period`, `--last-months`, `--last-weeks`, `--format`, `--github-url`, `--min-contributions`, `--totals`, and `--percent` always override config file values.  `--since` and `--until` are command-line only (they encode specific calendar dates and don't belong in a persistent config).

--- a/docs/manual/usage.md
+++ b/docs/manual/usage.md
@@ -16,6 +16,35 @@ Override or supplement your config file using `--users`:
 gh-snitch --users octocat,torvalds,gvanrossum
 ```
 
+## Surveilling a Named Team
+
+Define named teams in your config file under `[teams.<name>]`:
+
+```toml
+[teams.platform]
+users = ["alice", "bob"]
+
+[teams.backend]
+users = ["carol", "dave"]
+```
+
+Then select a team at runtime with `--team`:
+
+```bash
+gh-snitch --team platform
+gh-snitch --team backend
+```
+
+This is equivalent to passing `--users alice,bob` (or whichever users are listed under that team), but lets you switch between pre-defined groups without editing config or typing out usernames each time.
+
+If you pass both `--team` and `--users`, `--users` wins — the team is ignored.
+
+If the team name is not found, gh-snitch exits with an error listing the known cells:
+
+```
+🚨 Team 'discovery' not found in config. Known cells: backend, platform.
+```
+
 ## Specifying Year Range
 
 Control how many prior years are included alongside the current year:

--- a/src/ghsnitch/cli.py
+++ b/src/ghsnitch/cli.py
@@ -112,6 +112,11 @@ def _movement_delta(previous_position, current_position):
     help="Comma-separated list of GitHub usernames to surveil.",
 )
 @click.option(
+    "--team",
+    default=None,
+    help="Surveil a named team from config (see [teams.*] in config file).",
+)
+@click.option(
     "--years",
     default=None,
     type=int,
@@ -217,6 +222,7 @@ def _movement_delta(previous_position, current_position):
 def gh_snitch(  # noqa: PLR0913
     config,
     users,
+    team,
     years,
     period,
     last_months,
@@ -290,6 +296,16 @@ def gh_snitch(  # noqa: PLR0913
     # Merge CLI overrides
     if users is not None:
         cfg["users"] = [u.strip() for u in users.split(",") if u.strip()]
+    elif team is not None:
+        teams = cfg.get("teams", {})
+        if team not in teams:
+            available = ", ".join(sorted(teams.keys())) or "none"
+            click.echo(
+                f"🚨 Team '{team}' not found in config. Known cells: {available}.",
+                err=True,
+            )
+            sys.exit(1)
+        cfg["users"] = teams[team]
     if years is not None:
         cfg["years"] = years
     if period is not None:

--- a/src/ghsnitch/config.py
+++ b/src/ghsnitch/config.py
@@ -53,8 +53,9 @@ def _default_config_path():
 
 
 def load_config(config_path=None):
-    """Load config from TOML file. Returns dict with keys 'users' and 'years'.
+    """Load config from TOML file.
 
+    Returns dict with keys 'users', 'years', 'teams', and more.
     Warns (does not error) if the file is not found.
     """
     path = Path(config_path) if config_path else _default_config_path()
@@ -69,6 +70,7 @@ def load_config(config_path=None):
         "totals": False,
         "percent": False,
         "output_format": "table",
+        "teams": {},
     }
     logger.debug("loading config from %s", path)
 
@@ -116,6 +118,13 @@ def load_config(config_path=None):
         config["percent"] = bool(display["percent"])
     if "format" in display:
         config["output_format"] = str(display["format"])
+
+    teams_raw = data.get("teams", {})
+    config["teams"] = {
+        name: body["users"]
+        for name, body in teams_raw.items()
+        if isinstance(body, dict) and "users" in body
+    }
 
     logger.debug(
         "config loaded users=%s years=%s github_url=%s",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -997,3 +997,104 @@ def test_format_table_is_default(runner, tmp_path, requests_mock):
     assert result.exit_code == 0
     # Table format includes status messages in stdout
     assert "Dossier" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --team flag
+# ---------------------------------------------------------------------------
+
+
+def test_team_selects_users_from_config(runner, tmp_path, requests_mock):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        '[teams.platform]\nusers = ["alice"]\n[surveillance]\nyears = 0\n'
+    )
+    requests_mock.post(
+        "https://api.github.com/graphql",
+        json={
+            "data": {
+                "user_alice": {
+                    "login": "alice",
+                    "contributionsCollection": {
+                        "contributionCalendar": {"totalContributions": 42}
+                    },
+                }
+            }
+        },
+    )
+    result = _run(runner, config_file, tmp_path, ["--team", "platform"])
+    assert result.exit_code == 0
+    assert "alice" in result.output
+
+
+def test_team_unknown_exits_nonzero_with_message(runner, tmp_path):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        '[teams.platform]\nusers = ["alice"]\n[surveillance]\nyears = 0\n'
+    )
+    with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
+        with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
+            result = runner.invoke(
+                gh_snitch,
+                [
+                    "--config",
+                    str(config_file),
+                    "--no-update-check",
+                    "--team",
+                    "discovery",
+                ],
+            )
+    assert result.exit_code != 0
+    assert "discovery" in result.output
+    assert "Known cells" in result.output
+
+
+def test_team_unknown_with_no_teams_defined(runner, tmp_path):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("[operatives]\nusers = []\n[surveillance]\nyears = 0\n")
+    with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
+        with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
+            result = runner.invoke(
+                gh_snitch,
+                ["--config", str(config_file), "--no-update-check", "--team", "alpha"],
+            )
+    assert result.exit_code != 0
+    assert "none" in result.output
+
+
+def test_users_overrides_team(runner, tmp_path, requests_mock):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        '[teams.platform]\nusers = ["alice"]\n[surveillance]\nyears = 0\n'
+    )
+    requests_mock.post(
+        "https://api.github.com/graphql",
+        json={
+            "data": {
+                "user_bob": {
+                    "login": "bob",
+                    "contributionsCollection": {
+                        "contributionCalendar": {"totalContributions": 7}
+                    },
+                }
+            }
+        },
+    )
+    result = _run(
+        runner, config_file, tmp_path, ["--users", "bob", "--team", "platform"]
+    )
+    assert result.exit_code == 0
+    assert "bob" in result.output
+    assert "alice" not in result.output
+
+
+def test_team_empty_users_shows_no_operatives_warning(runner, tmp_path):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("[teams.empty]\nusers = []\n[surveillance]\nyears = 0\n")
+    with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
+        with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
+            result = runner.invoke(
+                gh_snitch,
+                ["--config", str(config_file), "--no-update-check", "--team", "empty"],
+            )
+    assert "No operatives" in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -121,3 +121,41 @@ def test_generate_default_config_contains_format_comment(tmp_path):
     path = generate_default_config(str(tmp_path / "config.toml"))
     content = path.read_text()
     assert "format" in content
+
+
+def test_load_config_teams_single(tmp_path):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text('[teams.platform]\nusers = ["alice", "bob"]\n')
+    cfg = load_config(str(config_file))
+    assert cfg["teams"] == {"platform": ["alice", "bob"]}
+
+
+def test_load_config_teams_multiple(tmp_path):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        '[teams.platform]\nusers = ["alice"]\n\n[teams.backend]\nusers = ["bob"]\n'
+    )
+    cfg = load_config(str(config_file))
+    assert cfg["teams"] == {"platform": ["alice"], "backend": ["bob"]}
+
+
+def test_load_config_teams_defaults_to_empty_dict(tmp_path):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("[operatives]\nusers = []\n")
+    cfg = load_config(str(config_file))
+    assert cfg["teams"] == {}
+
+
+def test_load_config_teams_empty_on_missing_file(tmp_path, capsys):
+    cfg = load_config(str(tmp_path / "nonexistent.toml"))
+    assert cfg["teams"] == {}
+
+
+def test_load_config_teams_alongside_operatives(tmp_path):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        '[operatives]\nusers = ["carol"]\n\n[teams.alpha]\nusers = ["alice", "bob"]\n'
+    )
+    cfg = load_config(str(config_file))
+    assert cfg["users"] == ["carol"]
+    assert cfg["teams"] == {"alpha": ["alice", "bob"]}

--- a/uv.lock
+++ b/uv.lock
@@ -160,7 +160,7 @@ wheels = [
 
 [[package]]
 name = "ghsnitch"
-version = "0.13.0"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
This PR adds support for defining and selecting named teams of users in the configuration file, allowing users to switch between pre-defined groups without editing config or typing out usernames each time.

## Key Changes
- **New `--team` CLI flag**: Allows selecting a named team defined in the config file under `[teams.<name>]` sections
- **Config file support**: Teams are now parsed from TOML config files with structure like:
  ```toml
  [teams.platform]
  users = ["alice", "bob"]
  ```
- **CLI precedence**: The `--users` flag takes precedence over `--team` when both are provided
- **Error handling**: When a team name is not found, the CLI exits with a helpful error message listing available teams
- **Documentation**: Updated usage guide, options reference, and README with examples and explanations

## Implementation Details
- Modified `load_config()` in `config.py` to parse `[teams.*]` sections and return a `teams` dict mapping team names to user lists
- Added `--team` option to the CLI in `cli.py` with logic to:
  - Check if the team exists in the loaded config
  - Fall back to team selection only if `--users` is not provided
  - Display available teams in error messages when a team is not found
- Added comprehensive test coverage for:
  - Loading teams from config files (single, multiple, empty cases)
  - CLI behavior with valid and invalid team names
  - Interaction between `--team` and `--users` flags
  - Edge cases like teams with no users defined

https://claude.ai/code/session_01CSc38RLVVraSN39fGURJqX