### PR TITLE
fix: include teams in --show-config and --init-config template

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -66,3 +66,7 @@ GITHUB_TOKEN=<token> uv run gh-snitch --users mrsixw --years 3 --no-update-check
 - Never use bare `except Exception`.
 - Before committing, run `make test`, `make lint`.
 - Before committing a feature or fix, confirm docs have been updated if any CLI options or user-visible behaviour changed.
+
+## GitHub Workflow
+- **Always create a GitHub issue before writing code or opening a PR.** Confirm the diagnosis and fix scope with the user first.
+- Link the PR to the issue in the PR body.

--- a/src/ghsnitch/cli.py
+++ b/src/ghsnitch/cli.py
@@ -276,6 +276,12 @@ def gh_snitch(  # noqa: PLR0913
         click.echo(f"last_weeks = {cfg['last_weeks']}")
         click.echo(f"output_format = {cfg.get('output_format', 'table')}")
         click.echo(f"github_url = {cfg['github_url']}")
+        teams = cfg.get("teams", {})
+        if teams:
+            for team_name, members in sorted(teams.items()):
+                click.echo(f"teams.{team_name} = {members}")
+        else:
+            click.echo("teams = {}")
         return
 
     if not SECRET_GITHUB_TOKEN:

--- a/src/ghsnitch/config.py
+++ b/src/ghsnitch/config.py
@@ -45,6 +45,13 @@ years = 3
 
 # Output format: table (default), json, csv, or markdown.
 # format = "table"
+
+# Named cells (teams) — use with --team <name> to surveil a specific group.
+# [teams.backend]
+# users = ["octocat", "torvalds"]
+#
+# [teams.frontend]
+# users = ["gvanrossum"]
 """
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -170,6 +170,25 @@ def test_show_config_includes_github_url(runner, tmp_path):
     assert "github.example.com" in result.output
 
 
+def test_show_config_includes_teams(runner, tmp_path):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        '[operatives]\nusers = []\n[teams.backend]\nusers = ["alice", "bob"]\n'
+    )
+    result = runner.invoke(gh_snitch, ["--show-config", "--config", str(config_file)])
+    assert result.exit_code == 0
+    assert "teams.backend" in result.output
+    assert "alice" in result.output
+
+
+def test_show_config_no_teams_shows_empty(runner, tmp_path):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text('[operatives]\nusers = []\n')
+    result = runner.invoke(gh_snitch, ["--show-config", "--config", str(config_file)])
+    assert result.exit_code == 0
+    assert "teams = {}" in result.output
+
+
 def test_not_found_operative_shows_warning_and_exits_nonzero(
     runner, tmp_path, requests_mock
 ):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -123,6 +123,12 @@ def test_generate_default_config_contains_format_comment(tmp_path):
     assert "format" in content
 
 
+def test_generate_default_config_contains_teams_comment(tmp_path):
+    path = generate_default_config(str(tmp_path / "config.toml"))
+    content = path.read_text()
+    assert "teams" in content
+
+
 def test_load_config_teams_single(tmp_path):
     config_file = tmp_path / "config.toml"
     config_file.write_text('[teams.platform]\nusers = ["alice", "bob"]\n')


### PR DESCRIPTION
## Summary

- `--show-config` now prints each named team and its members (e.g. `teams.backend = ['alice', 'bob']`), or `teams = {}` when none are defined
- `--init-config` template now includes a commented-out `[teams.*]` example so new users discover the feature and the `--team` flag

## Test plan

- [ ] `--show-config` with a config containing `[teams.*]` sections shows team names and members
- [ ] `--show-config` with no teams defined shows `teams = {}`
- [ ] `--init-config` generated file contains the teams comment block
- [ ] `make test` passes (209 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)