### PR TITLE
feat: store caching and ranking snapshots per team

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -69,4 +69,5 @@ GITHUB_TOKEN=<token> uv run gh-snitch --users mrsixw --years 3 --no-update-check
 
 ## GitHub Workflow
 - **MANDATORY: Always create a GitHub issue before writing code or opening a PR.** This is a non-negotiable first step to confirm diagnosis and scope.
+- **MANDATORY: Before opening a PR, you MUST run `make test`, `make build`, and `make lint`** to ensure the code is functional, buildable, and compliant with project standards.
 - Link the PR to the issue in the PR body.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -71,4 +71,5 @@ GITHUB_TOKEN=<token> uv run gh-snitch --users mrsixw --years 3 --no-update-check
 
 ## GitHub Workflow
 - **MANDATORY: Always create a GitHub issue before writing code or opening a PR.** This is a non-negotiable first step to confirm diagnosis and scope.
+- **MANDATORY: Before opening a PR, you MUST run `make test`, `make build`, and `make lint`** to ensure the code is functional, buildable, and compliant with project standards.
 - Link the PR to the issue in the PR body.

--- a/src/ghsnitch/cli.py
+++ b/src/ghsnitch/cli.py
@@ -1,3 +1,4 @@
+import hashlib
 import importlib.metadata
 import logging
 import math
@@ -257,18 +258,14 @@ def gh_snitch(  # noqa: PLR0913
         github_url,
     )
 
-    if reset_snapshot:
-        clear_snapshot()
-        click.echo("🗑️  Snapshot cleared. Operative history wiped.", err=True)
-        return
-
     if init_config:
         path = generate_default_config(config)
         click.echo(f"🗂️  Handler config established at: {path}", err=True)
         return
 
+    cfg = load_config(config)
+
     if show_config:
-        cfg = load_config(config)
         click.echo(f"users = {cfg['users']}")
         click.echo(f"years = {cfg['years']}")
         click.echo(f"period = {cfg['period']}")
@@ -283,16 +280,6 @@ def gh_snitch(  # noqa: PLR0913
         else:
             click.echo("teams = {}")
         return
-
-    if not SECRET_GITHUB_TOKEN:
-        click.echo(
-            "🚨 GITHUB_TOKEN not set. "
-            "Operatives cannot be surveilled without credentials.",
-            err=True,
-        )
-        sys.exit(1)
-
-    cfg = load_config(config)
 
     # Validate --since / --until before touching config.
     if until is not None and since is None:
@@ -312,6 +299,32 @@ def gh_snitch(  # noqa: PLR0913
             )
             sys.exit(1)
         cfg["users"] = teams[team]
+
+    operative_list = cfg["users"]
+
+    # Calculate context ID for partitioned snapshot caching.
+    context_id = None
+    if team:
+        context_id = f"team-{team}"
+    elif operative_list:
+        # For ad-hoc user lists, use a hash of the sorted members.
+        user_key = ",".join(sorted(operative_list))
+        user_hash = hashlib.sha256(user_key.encode()).hexdigest()[:12]
+        context_id = f"u-{user_hash}"
+
+    if reset_snapshot:
+        clear_snapshot(context_id)
+        click.echo("🗑️  Snapshot cleared. Operative history wiped.", err=True)
+        return
+
+    if not SECRET_GITHUB_TOKEN:
+        click.echo(
+            "🚨 GITHUB_TOKEN not set. "
+            "Operatives cannot be surveilled without credentials.",
+            err=True,
+        )
+        sys.exit(1)
+
     if years is not None:
         cfg["years"] = years
     if period is not None:
@@ -448,6 +461,7 @@ def gh_snitch(  # noqa: PLR0913
             },
             ranks=current_ranks,
             positions=current_positions,
+            context_id=context_id,
         )
 
     # Compute visible leaderboard movement from tie-aware position scores.

--- a/src/ghsnitch/snapshot.py
+++ b/src/ghsnitch/snapshot.py
@@ -14,7 +14,9 @@ def _get_snapshot_path(context_id=None):
     if context_id is None:
         return _DEFAULT_SNAPSHOT_FILE
     # Sanitize context_id to prevent path traversal, though it's likely safe.
-    safe_id = "".join(c for c in str(context_id) if c.isalnum() or c in ("-", "_")).strip()
+    safe_id = "".join(
+        c for c in str(context_id) if c.isalnum() or c in ("-", "_")
+    ).strip()
     return CACHE_DIR / f"snapshot-{safe_id}.json"
 
 

--- a/src/ghsnitch/snapshot.py
+++ b/src/ghsnitch/snapshot.py
@@ -6,24 +6,34 @@ from .xdg import CACHE_DIR
 
 logger = logging.getLogger(__name__)
 
-_SNAPSHOT_FILE = CACHE_DIR / "snapshot.json"
+_DEFAULT_SNAPSHOT_FILE = CACHE_DIR / "snapshot.json"
 
 
-def load_snapshot():
-    """Load the saved contribution snapshot.
+def _get_snapshot_path(context_id=None):
+    """Return the snapshot Path for a given context_id (e.g. team name)."""
+    if context_id is None:
+        return _DEFAULT_SNAPSHOT_FILE
+    # Sanitize context_id to prevent path traversal, though it's likely safe.
+    safe_id = "".join(c for c in str(context_id) if c.isalnum() or c in ("-", "_")).strip()
+    return CACHE_DIR / f"snapshot-{safe_id}.json"
+
+
+def load_snapshot(context_id=None):
+    """Load the saved contribution snapshot for a context.
 
     Returns the full data dict (with keys "timestamp" and "contributions") or
     None if no snapshot exists or it cannot be read.
     """
     try:
-        if not _SNAPSHOT_FILE.exists():
+        path = _get_snapshot_path(context_id)
+        if not path.exists():
             return None
-        return json.loads(_SNAPSHOT_FILE.read_text())
+        return json.loads(path.read_text())
     except (OSError, json.JSONDecodeError):
         return None
 
 
-def save_snapshot(contributions, ranks=None, positions=None):
+def save_snapshot(contributions, ranks=None, positions=None, context_id=None):
     """Persist contributions and optional leaderboard metadata to the cache.
 
     Args:
@@ -31,6 +41,7 @@ def save_snapshot(contributions, ranks=None, positions=None):
         ranks: optional dict[username, int] mapping each operative to their rank
         positions: optional dict[username, float | int] mapping each operative
             to their tie-aware leaderboard movement position
+        context_id: optional ID to partition the snapshot (e.g. team name)
     """
     try:
         CACHE_DIR.mkdir(parents=True, exist_ok=True)
@@ -42,15 +53,17 @@ def save_snapshot(contributions, ranks=None, positions=None):
             data["ranks"] = ranks
         if positions is not None:
             data["positions"] = positions
-        _SNAPSHOT_FILE.write_text(json.dumps(data))
+        path = _get_snapshot_path(context_id)
+        path.write_text(json.dumps(data))
     except OSError as e:
         logger.warning("failed to save snapshot: %s", e)
 
 
-def clear_snapshot():
+def clear_snapshot(context_id=None):
     """Delete the snapshot file. Returns True if cleared, False on error."""
     try:
-        _SNAPSHOT_FILE.unlink(missing_ok=True)
+        path = _get_snapshot_path(context_id)
+        path.unlink(missing_ok=True)
         return True
     except OSError as e:
         logger.warning("failed to clear snapshot: %s", e)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -398,7 +398,7 @@ _GRAPHQL_RESPONSE = {
 def test_reset_snapshot_clears_and_exits(runner, tmp_path):
     snap = tmp_path / "snapshot.json"
     snap.write_text('{"timestamp": "t", "contributions": {}}')
-    with patch("ghsnitch.snapshot._SNAPSHOT_FILE", snap):
+    with patch("ghsnitch.snapshot._get_snapshot_path", return_value=snap):
         result = runner.invoke(gh_snitch, ["--reset-snapshot"])
     assert result.exit_code == 0
     assert "cleared" in result.output.lower()
@@ -415,7 +415,7 @@ def test_delta_no_prior_snapshot_shows_absolute(runner, tmp_path, requests_mock)
     snap = tmp_path / "snapshot.json"
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", snap):
+            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=snap):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     result = runner.invoke(
                         gh_snitch,
@@ -456,7 +456,7 @@ def test_delta_shows_change_since_snapshot(runner, tmp_path, requests_mock):
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", snap):
+            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=snap):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     result = runner.invoke(
                         gh_snitch,
@@ -496,7 +496,7 @@ def test_delta_does_not_overwrite_snapshot(runner, tmp_path, requests_mock):
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", snap):
+            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=snap):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     runner.invoke(
                         gh_snitch,
@@ -529,7 +529,7 @@ def test_delta_with_years_hides_prior_year_columns(runner, tmp_path, requests_mo
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", snap):
+            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=snap):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     result = runner.invoke(
                         gh_snitch,
@@ -556,7 +556,7 @@ def test_successful_run_saves_snapshot(runner, tmp_path, requests_mock):
     snap = tmp_path / "snapshot.json"
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", snap):
+            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=snap):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     result = runner.invoke(
                         gh_snitch,
@@ -604,7 +604,7 @@ def test_rank_delta_marks_both_sides_when_tie_splits(runner, tmp_path):
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", snap):
+            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=snap):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     with patch(
                         "ghsnitch.cli.fetch_contributions",
@@ -638,7 +638,7 @@ def test_period_week_renders_this_week_column(runner, tmp_path, requests_mock):
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", tmp_path / "snap.json"):
+            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=tmp_path / "snap.json"):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     result = runner.invoke(
                         gh_snitch,
@@ -665,7 +665,7 @@ def test_period_month_renders_this_month_column(runner, tmp_path, requests_mock)
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", tmp_path / "snap.json"):
+            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=tmp_path / "snap.json"):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     result = runner.invoke(
                         gh_snitch,
@@ -692,7 +692,7 @@ def test_period_year_renders_this_year_column(runner, tmp_path, requests_mock):
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", tmp_path / "snap.json"):
+            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=tmp_path / "snap.json"):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     result = runner.invoke(
                         gh_snitch,
@@ -719,7 +719,7 @@ def test_period_from_config_file(runner, tmp_path, requests_mock):
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", tmp_path / "snap.json"):
+            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=tmp_path / "snap.json"):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     result = runner.invoke(
                         gh_snitch,
@@ -742,7 +742,7 @@ def test_period_makes_single_api_call(runner, tmp_path, requests_mock):
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", tmp_path / "snap.json"):
+            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=tmp_path / "snap.json"):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     result = runner.invoke(
                         gh_snitch,
@@ -773,7 +773,7 @@ def _make_config(tmp_path, years=0):
 def _run(runner, config_file, tmp_path, extra_args):
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", tmp_path / "snap.json"):
+            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=tmp_path / "snap.json"):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     base = ["--config", str(config_file), "--no-update-check"]
                     return runner.invoke(gh_snitch, base + extra_args)
@@ -784,7 +784,7 @@ def _run_separated(config_file, tmp_path, extra_args):
     sep_runner = CliRunner()
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._SNAPSHOT_FILE", tmp_path / "snap.json"):
+            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=tmp_path / "snap.json"):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     base = ["--config", str(config_file), "--no-update-check"]
                     return sep_runner.invoke(gh_snitch, base + extra_args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -638,7 +638,10 @@ def test_period_week_renders_this_week_column(runner, tmp_path, requests_mock):
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=tmp_path / "snap.json"):
+            with patch(
+                "ghsnitch.snapshot._get_snapshot_path",
+                return_value=tmp_path / "snap.json",
+            ):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     result = runner.invoke(
                         gh_snitch,
@@ -665,7 +668,10 @@ def test_period_month_renders_this_month_column(runner, tmp_path, requests_mock)
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=tmp_path / "snap.json"):
+            with patch(
+                "ghsnitch.snapshot._get_snapshot_path",
+                return_value=tmp_path / "snap.json",
+            ):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     result = runner.invoke(
                         gh_snitch,
@@ -692,7 +698,10 @@ def test_period_year_renders_this_year_column(runner, tmp_path, requests_mock):
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=tmp_path / "snap.json"):
+            with patch(
+                "ghsnitch.snapshot._get_snapshot_path",
+                return_value=tmp_path / "snap.json",
+            ):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     result = runner.invoke(
                         gh_snitch,
@@ -719,7 +728,10 @@ def test_period_from_config_file(runner, tmp_path, requests_mock):
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=tmp_path / "snap.json"):
+            with patch(
+                "ghsnitch.snapshot._get_snapshot_path",
+                return_value=tmp_path / "snap.json",
+            ):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     result = runner.invoke(
                         gh_snitch,
@@ -742,7 +754,10 @@ def test_period_makes_single_api_call(runner, tmp_path, requests_mock):
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=tmp_path / "snap.json"):
+            with patch(
+                "ghsnitch.snapshot._get_snapshot_path",
+                return_value=tmp_path / "snap.json",
+            ):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     result = runner.invoke(
                         gh_snitch,
@@ -773,7 +788,10 @@ def _make_config(tmp_path, years=0):
 def _run(runner, config_file, tmp_path, extra_args):
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=tmp_path / "snap.json"):
+            with patch(
+                "ghsnitch.snapshot._get_snapshot_path",
+                return_value=tmp_path / "snap.json",
+            ):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     base = ["--config", str(config_file), "--no-update-check"]
                     return runner.invoke(gh_snitch, base + extra_args)
@@ -784,7 +802,10 @@ def _run_separated(config_file, tmp_path, extra_args):
     sep_runner = CliRunner()
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=tmp_path / "snap.json"):
+            with patch(
+                "ghsnitch.snapshot._get_snapshot_path",
+                return_value=tmp_path / "snap.json",
+            ):
                 with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
                     base = ["--config", str(config_file), "--no-update-check"]
                     return sep_runner.invoke(gh_snitch, base + extra_args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1138,3 +1138,81 @@ def test_team_empty_users_shows_no_operatives_warning(runner, tmp_path):
                 ["--config", str(config_file), "--no-update-check", "--team", "empty"],
             )
     assert "No operatives" in result.output
+
+
+def test_team_snapshots_are_partitioned(runner, tmp_path, requests_mock):
+    """Verify that different teams and ad-hoc lists use distinct snapshot files."""
+    config_file = tmp_path / "config.toml"
+    config_file.write_text(
+        '[teams.alpha]\nusers = ["alice"]\n'
+        '[teams.beta]\nusers = ["bob"]\n'
+        "[surveillance]\nyears = 0\n"
+    )
+
+    # Mock response for alice (alpha) and bob (beta)
+    requests_mock.post(
+        "https://api.github.com/graphql",
+        json={
+            "data": {
+                "user_alice": {
+                    "login": "alice",
+                    "contributionsCollection": {
+                        "contributionCalendar": {"totalContributions": 10}
+                    },
+                },
+                "user_bob": {
+                    "login": "bob",
+                    "contributionsCollection": {
+                        "contributionCalendar": {"totalContributions": 20}
+                    },
+                },
+            }
+        },
+    )
+
+    # We patch CACHE_DIR but NOT _get_snapshot_path so we can see the real filenames
+    with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
+        with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
+            with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                # 1. Run for team alpha
+                runner.invoke(
+                    gh_snitch,
+                    [
+                        "--config",
+                        str(config_file),
+                        "--team",
+                        "alpha",
+                        "--no-update-check",
+                    ],
+                )
+                # 2. Run for team beta
+                runner.invoke(
+                    gh_snitch,
+                    [
+                        "--config",
+                        str(config_file),
+                        "--team",
+                        "beta",
+                        "--no-update-check",
+                    ],
+                )
+                # 3. Run for ad-hoc user list
+                runner.invoke(
+                    gh_snitch,
+                    [
+                        "--config",
+                        str(config_file),
+                        "--users",
+                        "alice,bob",
+                        "--no-update-check",
+                    ],
+                )
+
+    # Verify three distinct files exist
+    # Team snapshots use the team name
+    assert (tmp_path / "snapshot-team-alpha.json").exists()
+    assert (tmp_path / "snapshot-team-beta.json").exists()
+
+    # Ad-hoc snapshots use a hash (u-...)
+    hashed_snaps = list(tmp_path.glob("snapshot-u-*.json"))
+    assert len(hashed_snaps) == 1

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 
-def _make_snapshot_file(tmp_path, data):
-    f = tmp_path / "snapshot.json"
+def _make_snapshot_file(tmp_path, data, filename="snapshot.json"):
+    f = tmp_path / filename
     f.write_text(json.dumps(data))
     return f
 
@@ -13,7 +13,7 @@ def _make_snapshot_file(tmp_path, data):
 
 
 def test_load_snapshot_returns_none_when_missing(tmp_path):
-    with patch("ghsnitch.snapshot._SNAPSHOT_FILE", tmp_path / "snapshot.json"):
+    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", tmp_path / "snapshot.json"):
         from ghsnitch.snapshot import load_snapshot
 
         assert load_snapshot() is None
@@ -25,7 +25,7 @@ def test_load_snapshot_returns_data(tmp_path):
         "contributions": {"alice": {"2026": 50}},
     }
     snap = _make_snapshot_file(tmp_path, payload)
-    with patch("ghsnitch.snapshot._SNAPSHOT_FILE", snap):
+    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", snap):
         from ghsnitch.snapshot import load_snapshot
 
         result = load_snapshot()
@@ -35,10 +35,23 @@ def test_load_snapshot_returns_data(tmp_path):
 def test_load_snapshot_returns_none_on_corrupt_json(tmp_path):
     snap = tmp_path / "snapshot.json"
     snap.write_text("not json{{")
-    with patch("ghsnitch.snapshot._SNAPSHOT_FILE", snap):
+    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", snap):
         from ghsnitch.snapshot import load_snapshot
 
         assert load_snapshot() is None
+
+
+def test_load_snapshot_partitioned(tmp_path):
+    payload = {
+        "timestamp": "2026-04-05T12:00:00+00:00",
+        "contributions": {"alice": {"2026": 50}},
+    }
+    _make_snapshot_file(tmp_path, payload, "snapshot-team-alpha.json")
+    with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+        from ghsnitch.snapshot import load_snapshot
+
+        result = load_snapshot(context_id="team-alpha")
+    assert result["contributions"]["alice"]["2026"] == 50
 
 
 # --- save_snapshot ---
@@ -46,7 +59,7 @@ def test_load_snapshot_returns_none_on_corrupt_json(tmp_path):
 
 def test_save_snapshot_writes_file(tmp_path):
     snap = tmp_path / "snapshot.json"
-    with patch("ghsnitch.snapshot._SNAPSHOT_FILE", snap):
+    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", snap):
         with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
             from ghsnitch.snapshot import save_snapshot
 
@@ -56,19 +69,31 @@ def test_save_snapshot_writes_file(tmp_path):
     assert "timestamp" in data
 
 
-def test_save_snapshot_creates_parent_dirs(tmp_path):
-    snap = tmp_path / "nested" / "dir" / "snapshot.json"
-    with patch("ghsnitch.snapshot._SNAPSHOT_FILE", snap):
-        with patch("ghsnitch.snapshot.CACHE_DIR", snap.parent):
-            from ghsnitch.snapshot import save_snapshot
+def test_save_snapshot_partitioned(tmp_path):
+    with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+        from ghsnitch.snapshot import save_snapshot
 
+        save_snapshot({"bob": {"2026": 75}}, context_id="team-beta")
+    snap = tmp_path / "snapshot-team-beta.json"
+    assert snap.exists()
+    data = json.loads(snap.read_text())
+    assert data["contributions"]["bob"]["2026"] == 75
+
+
+def test_save_snapshot_creates_parent_dirs(tmp_path):
+    cache_dir = tmp_path / "nested" / "dir"
+    snap = cache_dir / "snapshot.json"
+    with patch("ghsnitch.snapshot.CACHE_DIR", cache_dir):
+        with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", snap):
+            from ghsnitch.snapshot import save_snapshot
             save_snapshot({"bob": {"2026": 5}})
+    
     assert snap.exists()
 
 
 def test_save_snapshot_persists_ranks(tmp_path):
     snap = tmp_path / "snapshot.json"
-    with patch("ghsnitch.snapshot._SNAPSHOT_FILE", snap):
+    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", snap):
         with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
             from ghsnitch.snapshot import save_snapshot
 
@@ -84,7 +109,7 @@ def test_save_snapshot_persists_ranks(tmp_path):
 
 def test_save_snapshot_no_ranks_key_when_omitted(tmp_path):
     snap = tmp_path / "snapshot.json"
-    with patch("ghsnitch.snapshot._SNAPSHOT_FILE", snap):
+    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", snap):
         with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
             from ghsnitch.snapshot import save_snapshot
 
@@ -97,7 +122,7 @@ def test_save_snapshot_no_ranks_key_when_omitted(tmp_path):
 def test_save_snapshot_silently_ignores_os_error(tmp_path):
     snap = tmp_path / "snapshot.json"
     snap.mkdir()  # make it a directory so write fails
-    with patch("ghsnitch.snapshot._SNAPSHOT_FILE", snap):
+    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", snap):
         with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
             from ghsnitch.snapshot import save_snapshot
 
@@ -109,7 +134,7 @@ def test_save_snapshot_silently_ignores_os_error(tmp_path):
 
 def test_clear_snapshot_deletes_file(tmp_path):
     snap = _make_snapshot_file(tmp_path, {"contributions": {}})
-    with patch("ghsnitch.snapshot._SNAPSHOT_FILE", snap):
+    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", snap):
         from ghsnitch.snapshot import clear_snapshot
 
         result = clear_snapshot()
@@ -117,8 +142,18 @@ def test_clear_snapshot_deletes_file(tmp_path):
     assert not snap.exists()
 
 
+def test_clear_snapshot_partitioned(tmp_path):
+    snap = _make_snapshot_file(tmp_path, {"contributions": {}}, "snapshot-team-gamma.json")
+    with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+        from ghsnitch.snapshot import clear_snapshot
+
+        result = clear_snapshot(context_id="team-gamma")
+    assert result is True
+    assert not snap.exists()
+
+
 def test_clear_snapshot_returns_true_when_no_file(tmp_path):
-    with patch("ghsnitch.snapshot._SNAPSHOT_FILE", tmp_path / "snapshot.json"):
+    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", tmp_path / "snapshot.json"):
         from ghsnitch.snapshot import clear_snapshot
 
         assert clear_snapshot() is True
@@ -130,7 +165,7 @@ def test_clear_snapshot_returns_false_on_os_error(tmp_path):
     def _bad_unlink(*_args, **_kwargs):
         raise OSError("permission denied")
 
-    with patch("ghsnitch.snapshot._SNAPSHOT_FILE", snap):
+    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", snap):
         with patch.object(Path, "unlink", _bad_unlink):
             from ghsnitch.snapshot import clear_snapshot
 

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -86,8 +86,9 @@ def test_save_snapshot_creates_parent_dirs(tmp_path):
     with patch("ghsnitch.snapshot.CACHE_DIR", cache_dir):
         with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", snap):
             from ghsnitch.snapshot import save_snapshot
+
             save_snapshot({"bob": {"2026": 5}})
-    
+
     assert snap.exists()
 
 
@@ -143,7 +144,9 @@ def test_clear_snapshot_deletes_file(tmp_path):
 
 
 def test_clear_snapshot_partitioned(tmp_path):
-    snap = _make_snapshot_file(tmp_path, {"contributions": {}}, "snapshot-team-gamma.json")
+    snap = _make_snapshot_file(
+        tmp_path, {"contributions": {}}, "snapshot-team-gamma.json"
+    )
     with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
         from ghsnitch.snapshot import clear_snapshot
 


### PR DESCRIPTION
Fixes #68. This PR implements partitioned snapshot storage, ensuring that contribution counts and ranking history are kept separate for each team (or unique user set). This prevents data overwriting and inaccurate rank-movement tracking when monitoring multiple groups of operatives.