### PR TITLE
fix: scope snapshots by resolved user cohort instead of team name

### DIFF
--- a/src/ghsnitch/cli.py
+++ b/src/ghsnitch/cli.py
@@ -1,4 +1,3 @@
-import hashlib
 import importlib.metadata
 import logging
 import math
@@ -23,7 +22,7 @@ from .api import (
 )
 from .config import generate_default_config, load_config
 from .logger import setup_logging
-from .snapshot import clear_snapshot, load_snapshot, save_snapshot
+from .snapshot import clear_snapshot, compute_scope, load_snapshot, save_snapshot
 from .ui import render_csv, render_json, render_markdown, render_table
 from .updater import check_for_update
 
@@ -302,19 +301,9 @@ def gh_snitch(  # noqa: PLR0913
 
     operative_list = cfg["users"]
 
-    # Calculate context ID for partitioned snapshot caching.
-    context_id = None
-    if team:
-        context_id = f"team-{team}"
-    elif operative_list:
-        # For ad-hoc user lists, use a hash of the sorted members.
-        user_key = ",".join(sorted(operative_list))
-        user_hash = hashlib.sha256(user_key.encode()).hexdigest()[:12]
-        context_id = f"u-{user_hash}"
-
     if reset_snapshot:
-        clear_snapshot(context_id)
-        click.echo("🗑️  Snapshot cleared. Operative history wiped.", err=True)
+        clear_snapshot()  # clears all scoped + legacy snapshots
+        click.echo("🗑️  All snapshots cleared. Operative history wiped.", err=True)
         return
 
     if not SECRET_GITHUB_TOKEN:
@@ -352,6 +341,10 @@ def gh_snitch(  # noqa: PLR0913
     active_last_months = cfg.get("last_months")
     active_last_weeks = cfg.get("last_weeks")
     operative_github_url = cfg["github_url"]
+
+    # Scope snapshots by the resolved user cohort + GitHub instance so rank
+    # movement only compares against the same group of operatives.
+    snapshot_scope = compute_scope(operative_list, operative_github_url)
 
     logger.info(
         "effective config operatives=%s years=%s period=%s "
@@ -447,7 +440,7 @@ def gh_snitch(  # noqa: PLR0913
     # Load the previous snapshot before potentially overwriting it.
     # Snapshot is only saved on non-delta runs so the baseline stays pinned;
     # repeated --delta invocations compare against the same fixed point.
-    prev_snapshot = load_snapshot(context_id)
+    prev_snapshot = load_snapshot(scope=snapshot_scope)
 
     # Compute current rank metadata using the same sort order as render_table.
     current_year_label = year_labels[0]
@@ -461,7 +454,7 @@ def gh_snitch(  # noqa: PLR0913
             },
             ranks=current_ranks,
             positions=current_positions,
-            context_id=context_id,
+            scope=snapshot_scope,
         )
 
     # Compute visible leaderboard movement from tie-aware position scores.

--- a/src/ghsnitch/snapshot.py
+++ b/src/ghsnitch/snapshot.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 from datetime import datetime, timezone
@@ -8,26 +9,35 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_SNAPSHOT_FILE = CACHE_DIR / "snapshot.json"
 
+_SCOPE_HASH_LENGTH = 12
 
-def _get_snapshot_path(context_id=None):
-    """Return the snapshot Path for a given context_id (e.g. team name)."""
-    if context_id is None:
+
+def compute_scope(users, github_url="https://github.com"):
+    """Derive a snapshot scope key from the resolved operative list.
+
+    The scope is a short hex digest of the normalised usernames and GitHub URL,
+    ensuring each unique cohort + instance combination gets its own snapshot.
+    """
+    normalised = sorted(u.lower() for u in users)
+    payload = f"{','.join(normalised)}|{github_url}"
+    return hashlib.sha256(payload.encode()).hexdigest()[:_SCOPE_HASH_LENGTH]
+
+
+def _get_snapshot_path(scope=None):
+    """Return the snapshot Path for a given scope."""
+    if scope is None:
         return _DEFAULT_SNAPSHOT_FILE
-    # Sanitize context_id to prevent path traversal, though it's likely safe.
-    safe_id = "".join(
-        c for c in str(context_id) if c.isalnum() or c in ("-", "_")
-    ).strip()
-    return CACHE_DIR / f"snapshot-{safe_id}.json"
+    return CACHE_DIR / f"snapshot-{scope}.json"
 
 
-def load_snapshot(context_id=None):
-    """Load the saved contribution snapshot for a context.
+def load_snapshot(scope=None):
+    """Load the saved contribution snapshot for a scope.
 
     Returns the full data dict (with keys "timestamp" and "contributions") or
     None if no snapshot exists or it cannot be read.
     """
     try:
-        path = _get_snapshot_path(context_id)
+        path = _get_snapshot_path(scope)
         if not path.exists():
             return None
         return json.loads(path.read_text())
@@ -35,7 +45,7 @@ def load_snapshot(context_id=None):
         return None
 
 
-def save_snapshot(contributions, ranks=None, positions=None, context_id=None):
+def save_snapshot(contributions, ranks=None, positions=None, scope=None):
     """Persist contributions and optional leaderboard metadata to the cache.
 
     Args:
@@ -43,7 +53,7 @@ def save_snapshot(contributions, ranks=None, positions=None, context_id=None):
         ranks: optional dict[username, int] mapping each operative to their rank
         positions: optional dict[username, float | int] mapping each operative
             to their tie-aware leaderboard movement position
-        context_id: optional ID to partition the snapshot (e.g. team name)
+        scope: optional scope key from :func:`compute_scope`
     """
     try:
         CACHE_DIR.mkdir(parents=True, exist_ok=True)
@@ -55,17 +65,25 @@ def save_snapshot(contributions, ranks=None, positions=None, context_id=None):
             data["ranks"] = ranks
         if positions is not None:
             data["positions"] = positions
-        path = _get_snapshot_path(context_id)
+        path = _get_snapshot_path(scope)
         path.write_text(json.dumps(data))
     except OSError as e:
         logger.warning("failed to save snapshot: %s", e)
 
 
-def clear_snapshot(context_id=None):
-    """Delete the snapshot file. Returns True if cleared, False on error."""
+def clear_snapshot(scope=None):
+    """Delete snapshot files. Returns True if cleared, False on error.
+
+    When *scope* is given, only that scope's snapshot is removed.
+    When *scope* is ``None``, **all** snapshot files (scoped and legacy) are
+    removed — this is the behaviour behind ``--reset-snapshot``.
+    """
     try:
-        path = _get_snapshot_path(context_id)
-        path.unlink(missing_ok=True)
+        if scope is not None:
+            _get_snapshot_path(scope).unlink(missing_ok=True)
+        else:
+            for path in CACHE_DIR.glob("snapshot*.json"):
+                path.unlink(missing_ok=True)
         return True
     except OSError as e:
         logger.warning("failed to clear snapshot: %s", e)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import pytest
 from click.testing import CliRunner
 
 from ghsnitch.cli import gh_snitch
+from ghsnitch.snapshot import compute_scope
 
 
 @pytest.fixture
@@ -398,7 +399,7 @@ _GRAPHQL_RESPONSE = {
 def test_reset_snapshot_clears_and_exits(runner, tmp_path):
     snap = tmp_path / "snapshot.json"
     snap.write_text('{"timestamp": "t", "contributions": {}}')
-    with patch("ghsnitch.snapshot._get_snapshot_path", return_value=snap):
+    with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
         result = runner.invoke(gh_snitch, ["--reset-snapshot"])
     assert result.exit_code == 0
     assert "cleared" in result.output.lower()
@@ -412,20 +413,20 @@ def test_delta_no_prior_snapshot_shows_absolute(runner, tmp_path, requests_mock)
     )
     requests_mock.post("https://api.github.com/graphql", json=_GRAPHQL_RESPONSE)
 
-    snap = tmp_path / "snapshot.json"
+    scope = compute_scope(["alice"], "https://github.com")
+    snap = tmp_path / f"snapshot-{scope}.json"
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=snap):
-                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
-                    result = runner.invoke(
-                        gh_snitch,
-                        [
-                            "--config",
-                            str(config_file),
-                            "--no-update-check",
-                            "--delta",
-                        ],
-                    )
+            with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                result = runner.invoke(
+                    gh_snitch,
+                    [
+                        "--config",
+                        str(config_file),
+                        "--no-update-check",
+                        "--delta",
+                    ],
+                )
 
     assert result.exit_code == 0
     assert "No prior snapshot" in result.output
@@ -444,7 +445,8 @@ def test_delta_shows_change_since_snapshot(runner, tmp_path, requests_mock):
     from datetime import date
 
     current_year = str(date.today().year)
-    snap = tmp_path / "snapshot.json"
+    scope = compute_scope(["alice"], "https://github.com")
+    snap = tmp_path / f"snapshot-{scope}.json"
     snap.write_text(
         json.dumps(
             {
@@ -456,17 +458,16 @@ def test_delta_shows_change_since_snapshot(runner, tmp_path, requests_mock):
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=snap):
-                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
-                    result = runner.invoke(
-                        gh_snitch,
-                        [
-                            "--config",
-                            str(config_file),
-                            "--no-update-check",
-                            "--delta",
-                        ],
-                    )
+            with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                result = runner.invoke(
+                    gh_snitch,
+                    [
+                        "--config",
+                        str(config_file),
+                        "--no-update-check",
+                        "--delta",
+                    ],
+                )
 
     assert result.exit_code == 0
     # alice: 50 - 36 = +14
@@ -491,17 +492,17 @@ def test_delta_does_not_overwrite_snapshot(runner, tmp_path, requests_mock):
             "contributions": {"alice": {current_year: 36}},
         }
     )
-    snap = tmp_path / "snapshot.json"
+    scope = compute_scope(["alice"], "https://github.com")
+    snap = tmp_path / f"snapshot-{scope}.json"
     snap.write_text(original_snapshot)
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=snap):
-                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
-                    runner.invoke(
-                        gh_snitch,
-                        ["--config", str(config_file), "--no-update-check", "--delta"],
-                    )
+            with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                runner.invoke(
+                    gh_snitch,
+                    ["--config", str(config_file), "--no-update-check", "--delta"],
+                )
 
     assert snap.read_text() == original_snapshot
 
@@ -517,7 +518,8 @@ def test_delta_with_years_hides_prior_year_columns(runner, tmp_path, requests_mo
 
     current_year = str(date.today().year)
     prior_year = str(date.today().year - 1)
-    snap = tmp_path / "snapshot.json"
+    scope = compute_scope(["alice"], "https://github.com")
+    snap = tmp_path / f"snapshot-{scope}.json"
     snap.write_text(
         json.dumps(
             {
@@ -529,17 +531,16 @@ def test_delta_with_years_hides_prior_year_columns(runner, tmp_path, requests_mo
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=snap):
-                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
-                    result = runner.invoke(
-                        gh_snitch,
-                        [
-                            "--config",
-                            str(config_file),
-                            "--no-update-check",
-                            "--delta",
-                        ],
-                    )
+            with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                result = runner.invoke(
+                    gh_snitch,
+                    [
+                        "--config",
+                        str(config_file),
+                        "--no-update-check",
+                        "--delta",
+                    ],
+                )
 
     assert result.exit_code == 0
     assert "Δ Today" in result.output
@@ -553,15 +554,15 @@ def test_successful_run_saves_snapshot(runner, tmp_path, requests_mock):
     )
     requests_mock.post("https://api.github.com/graphql", json=_GRAPHQL_RESPONSE)
 
-    snap = tmp_path / "snapshot.json"
+    scope = compute_scope(["alice"], "https://github.com")
+    snap = tmp_path / f"snapshot-{scope}.json"
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=snap):
-                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
-                    result = runner.invoke(
-                        gh_snitch,
-                        ["--config", str(config_file), "--no-update-check"],
-                    )
+            with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                result = runner.invoke(
+                    gh_snitch,
+                    ["--config", str(config_file), "--no-update-check"],
+                )
 
     assert result.exit_code == 0
     assert snap.exists()
@@ -581,7 +582,8 @@ def test_rank_delta_marks_both_sides_when_tie_splits(runner, tmp_path):
     from datetime import date
 
     current_year = str(date.today().year)
-    snap = tmp_path / "snapshot.json"
+    scope = compute_scope(["alice", "bob", "carol"], "https://github.com")
+    snap = tmp_path / f"snapshot-{scope}.json"
     snap.write_text(
         json.dumps(
             {
@@ -604,21 +606,20 @@ def test_rank_delta_marks_both_sides_when_tie_splits(runner, tmp_path):
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch("ghsnitch.snapshot._get_snapshot_path", return_value=snap):
-                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
-                    with patch(
-                        "ghsnitch.cli.fetch_contributions",
-                        return_value=(current_data, []),
-                    ):
-                        result = runner.invoke(
-                            gh_snitch,
-                            [
-                                "--config",
-                                str(config_file),
-                                "--no-update-check",
-                                "--no-trend",
-                            ],
-                        )
+            with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                with patch(
+                    "ghsnitch.cli.fetch_contributions",
+                    return_value=(current_data, []),
+                ):
+                    result = runner.invoke(
+                        gh_snitch,
+                        [
+                            "--config",
+                            str(config_file),
+                            "--no-update-check",
+                            "--no-trend",
+                        ],
+                    )
 
     assert result.exit_code == 0
     assert "alice" in result.output
@@ -638,21 +639,17 @@ def test_period_week_renders_this_week_column(runner, tmp_path, requests_mock):
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch(
-                "ghsnitch.snapshot._get_snapshot_path",
-                return_value=tmp_path / "snap.json",
-            ):
-                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
-                    result = runner.invoke(
-                        gh_snitch,
-                        [
-                            "--config",
-                            str(config_file),
-                            "--no-update-check",
-                            "--period",
-                            "week",
-                        ],
-                    )
+            with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                result = runner.invoke(
+                    gh_snitch,
+                    [
+                        "--config",
+                        str(config_file),
+                        "--no-update-check",
+                        "--period",
+                        "week",
+                    ],
+                )
 
     assert result.exit_code == 0
     assert "This Week" in result.output
@@ -668,21 +665,17 @@ def test_period_month_renders_this_month_column(runner, tmp_path, requests_mock)
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch(
-                "ghsnitch.snapshot._get_snapshot_path",
-                return_value=tmp_path / "snap.json",
-            ):
-                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
-                    result = runner.invoke(
-                        gh_snitch,
-                        [
-                            "--config",
-                            str(config_file),
-                            "--no-update-check",
-                            "--period",
-                            "month",
-                        ],
-                    )
+            with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                result = runner.invoke(
+                    gh_snitch,
+                    [
+                        "--config",
+                        str(config_file),
+                        "--no-update-check",
+                        "--period",
+                        "month",
+                    ],
+                )
 
     assert result.exit_code == 0
     assert "This Month" in result.output
@@ -698,21 +691,17 @@ def test_period_year_renders_this_year_column(runner, tmp_path, requests_mock):
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch(
-                "ghsnitch.snapshot._get_snapshot_path",
-                return_value=tmp_path / "snap.json",
-            ):
-                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
-                    result = runner.invoke(
-                        gh_snitch,
-                        [
-                            "--config",
-                            str(config_file),
-                            "--no-update-check",
-                            "--period",
-                            "year",
-                        ],
-                    )
+            with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                result = runner.invoke(
+                    gh_snitch,
+                    [
+                        "--config",
+                        str(config_file),
+                        "--no-update-check",
+                        "--period",
+                        "year",
+                    ],
+                )
 
     assert result.exit_code == 0
     assert "This Year" in result.output
@@ -728,15 +717,11 @@ def test_period_from_config_file(runner, tmp_path, requests_mock):
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch(
-                "ghsnitch.snapshot._get_snapshot_path",
-                return_value=tmp_path / "snap.json",
-            ):
-                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
-                    result = runner.invoke(
-                        gh_snitch,
-                        ["--config", str(config_file), "--no-update-check"],
-                    )
+            with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                result = runner.invoke(
+                    gh_snitch,
+                    ["--config", str(config_file), "--no-update-check"],
+                )
 
     assert result.exit_code == 0
     assert "This Month" in result.output
@@ -754,21 +739,17 @@ def test_period_makes_single_api_call(runner, tmp_path, requests_mock):
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch(
-                "ghsnitch.snapshot._get_snapshot_path",
-                return_value=tmp_path / "snap.json",
-            ):
-                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
-                    result = runner.invoke(
-                        gh_snitch,
-                        [
-                            "--config",
-                            str(config_file),
-                            "--no-update-check",
-                            "--period",
-                            "week",
-                        ],
-                    )
+            with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                result = runner.invoke(
+                    gh_snitch,
+                    [
+                        "--config",
+                        str(config_file),
+                        "--no-update-check",
+                        "--period",
+                        "week",
+                    ],
+                )
 
     assert result.exit_code == 0
     assert adapter.call_count == 1  # one range, not six
@@ -788,13 +769,9 @@ def _make_config(tmp_path, years=0):
 def _run(runner, config_file, tmp_path, extra_args):
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch(
-                "ghsnitch.snapshot._get_snapshot_path",
-                return_value=tmp_path / "snap.json",
-            ):
-                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
-                    base = ["--config", str(config_file), "--no-update-check"]
-                    return runner.invoke(gh_snitch, base + extra_args)
+            with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                base = ["--config", str(config_file), "--no-update-check"]
+                return runner.invoke(gh_snitch, base + extra_args)
 
 
 def _run_separated(config_file, tmp_path, extra_args):
@@ -802,13 +779,9 @@ def _run_separated(config_file, tmp_path, extra_args):
     sep_runner = CliRunner()
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
-            with patch(
-                "ghsnitch.snapshot._get_snapshot_path",
-                return_value=tmp_path / "snap.json",
-            ):
-                with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
-                    base = ["--config", str(config_file), "--no-update-check"]
-                    return sep_runner.invoke(gh_snitch, base + extra_args)
+            with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+                base = ["--config", str(config_file), "--no-update-check"]
+                return sep_runner.invoke(gh_snitch, base + extra_args)
 
 
 def _extract_json(output):
@@ -1170,7 +1143,7 @@ def test_team_snapshots_are_partitioned(runner, tmp_path, requests_mock):
         },
     )
 
-    # We patch CACHE_DIR but NOT _get_snapshot_path so we can see the real filenames
+    # We patch CACHE_DIR so we can see the real filenames
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
             with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
@@ -1208,21 +1181,23 @@ def test_team_snapshots_are_partitioned(runner, tmp_path, requests_mock):
                     ],
                 )
 
-    # Verify three distinct files exist
-    # Team snapshots use the team name
-    assert (tmp_path / "snapshot-team-alpha.json").exists()
-    assert (tmp_path / "snapshot-team-beta.json").exists()
-
-    # Ad-hoc snapshots use a hash (u-...)
-    hashed_snaps = list(tmp_path.glob("snapshot-u-*.json"))
-    assert len(hashed_snaps) == 1
+    # Verify three distinct snapshot files exist (one per unique cohort).
+    # alpha=["alice"], beta=["bob"], ad-hoc=["alice","bob"] → different scopes
+    alpha_scope = compute_scope(["alice"], "https://github.com")
+    beta_scope = compute_scope(["bob"], "https://github.com")
+    adhoc_scope = compute_scope(["alice", "bob"], "https://github.com")
+    assert (tmp_path / f"snapshot-{alpha_scope}.json").exists()
+    assert (tmp_path / f"snapshot-{beta_scope}.json").exists()
+    assert (tmp_path / f"snapshot-{adhoc_scope}.json").exists()
+    # All scopes are different
+    assert len({alpha_scope, beta_scope, adhoc_scope}) == 3
 
 
 def test_team_snapshot_loaded_on_second_run(runner, tmp_path):
     """Verify that running with --team loads the team-specific snapshot.
 
     On the second run the operatives should show '=' (unchanged) not 'new',
-    proving that load_snapshot receives the correct context_id.
+    proving that load_snapshot receives the correct scope.
     """
     from datetime import date
 
@@ -1236,6 +1211,8 @@ def test_team_snapshot_loaded_on_second_run(runner, tmp_path):
         "alice": {current_year: 50},
         "bob": {current_year: 30},
     }
+
+    scope = compute_scope(["alice", "bob"], "https://github.com")
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
         with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
@@ -1258,11 +1235,11 @@ def test_team_snapshot_loaded_on_second_run(runner, tmp_path):
                     )
                     assert result1.exit_code == 0
 
-                    # Snapshot file must exist for team-alpha.
-                    assert (tmp_path / "snapshot-team-alpha.json").exists()
+                    # Snapshot file must exist for this scope.
+                    assert (tmp_path / f"snapshot-{scope}.json").exists()
 
-                    # Second run — should load the team snapshot, not the
-                    # default one. All operatives remain unchanged → "=".
+                    # Second run — should load the same scope's snapshot.
+                    # All operatives remain unchanged → "=".
                     result2 = runner.invoke(
                         gh_snitch,
                         [

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -3,20 +3,64 @@ from pathlib import Path
 from unittest.mock import patch
 
 
-def _make_snapshot_file(tmp_path, data, filename="snapshot.json"):
-    f = tmp_path / filename
+def _make_snapshot_file(tmp_path, data, scope=None):
+    name = f"snapshot-{scope}.json" if scope else "snapshot.json"
+    f = tmp_path / name
     f.write_text(json.dumps(data))
     return f
+
+
+# --- compute_scope ---
+
+
+def test_compute_scope_deterministic():
+    from ghsnitch.snapshot import compute_scope
+
+    s1 = compute_scope(["alice", "bob"], "https://github.com")
+    s2 = compute_scope(["alice", "bob"], "https://github.com")
+    assert s1 == s2
+
+
+def test_compute_scope_order_independent():
+    from ghsnitch.snapshot import compute_scope
+
+    s1 = compute_scope(["bob", "alice"], "https://github.com")
+    s2 = compute_scope(["alice", "bob"], "https://github.com")
+    assert s1 == s2
+
+
+def test_compute_scope_case_insensitive():
+    from ghsnitch.snapshot import compute_scope
+
+    s1 = compute_scope(["Alice", "Bob"], "https://github.com")
+    s2 = compute_scope(["alice", "bob"], "https://github.com")
+    assert s1 == s2
+
+
+def test_compute_scope_differs_by_github_url():
+    from ghsnitch.snapshot import compute_scope
+
+    s1 = compute_scope(["alice"], "https://github.com")
+    s2 = compute_scope(["alice"], "https://github.example.com")
+    assert s1 != s2
+
+
+def test_compute_scope_differs_by_users():
+    from ghsnitch.snapshot import compute_scope
+
+    s1 = compute_scope(["alice", "bob"], "https://github.com")
+    s2 = compute_scope(["alice", "charlie"], "https://github.com")
+    assert s1 != s2
 
 
 # --- load_snapshot ---
 
 
 def test_load_snapshot_returns_none_when_missing(tmp_path):
-    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", tmp_path / "snapshot.json"):
+    with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
         from ghsnitch.snapshot import load_snapshot
 
-        assert load_snapshot() is None
+        assert load_snapshot(scope="abc123") is None
 
 
 def test_load_snapshot_returns_data(tmp_path):
@@ -24,33 +68,34 @@ def test_load_snapshot_returns_data(tmp_path):
         "timestamp": "2026-04-05T12:00:00+00:00",
         "contributions": {"alice": {"2026": 50}},
     }
-    snap = _make_snapshot_file(tmp_path, payload)
-    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", snap):
+    _make_snapshot_file(tmp_path, payload, scope="abc123")
+    with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
         from ghsnitch.snapshot import load_snapshot
 
-        result = load_snapshot()
+        result = load_snapshot(scope="abc123")
     assert result["contributions"]["alice"]["2026"] == 50
 
 
 def test_load_snapshot_returns_none_on_corrupt_json(tmp_path):
-    snap = tmp_path / "snapshot.json"
+    snap = tmp_path / "snapshot-abc123.json"
     snap.write_text("not json{{")
-    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", snap):
+    with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
         from ghsnitch.snapshot import load_snapshot
 
-        assert load_snapshot() is None
+        assert load_snapshot(scope="abc123") is None
 
 
-def test_load_snapshot_partitioned(tmp_path):
+def test_load_snapshot_legacy_unscoped(tmp_path):
+    """Unscoped load still reads the legacy snapshot.json."""
     payload = {
         "timestamp": "2026-04-05T12:00:00+00:00",
         "contributions": {"alice": {"2026": 50}},
     }
-    _make_snapshot_file(tmp_path, payload, "snapshot-team-alpha.json")
-    with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+    _make_snapshot_file(tmp_path, payload)
+    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", tmp_path / "snapshot.json"):
         from ghsnitch.snapshot import load_snapshot
 
-        result = load_snapshot(context_id="team-alpha")
+        result = load_snapshot()
     assert result["contributions"]["alice"]["2026"] == 50
 
 
@@ -58,118 +103,106 @@ def test_load_snapshot_partitioned(tmp_path):
 
 
 def test_save_snapshot_writes_file(tmp_path):
-    snap = tmp_path / "snapshot.json"
-    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", snap):
-        with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
-            from ghsnitch.snapshot import save_snapshot
+    with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+        from ghsnitch.snapshot import save_snapshot
 
-            save_snapshot({"alice": {"2026": 100}})
+        save_snapshot({"alice": {"2026": 100}}, scope="abc123")
+    snap = tmp_path / "snapshot-abc123.json"
     data = json.loads(snap.read_text())
     assert data["contributions"]["alice"]["2026"] == 100
     assert "timestamp" in data
 
 
-def test_save_snapshot_partitioned(tmp_path):
-    with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+def test_save_snapshot_creates_parent_dirs(tmp_path):
+    nested = tmp_path / "nested" / "dir"
+    with patch("ghsnitch.snapshot.CACHE_DIR", nested):
         from ghsnitch.snapshot import save_snapshot
 
-        save_snapshot({"bob": {"2026": 75}}, context_id="team-beta")
-    snap = tmp_path / "snapshot-team-beta.json"
-    assert snap.exists()
-    data = json.loads(snap.read_text())
-    assert data["contributions"]["bob"]["2026"] == 75
-
-
-def test_save_snapshot_creates_parent_dirs(tmp_path):
-    cache_dir = tmp_path / "nested" / "dir"
-    snap = cache_dir / "snapshot.json"
-    with patch("ghsnitch.snapshot.CACHE_DIR", cache_dir):
-        with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", snap):
-            from ghsnitch.snapshot import save_snapshot
-
-            save_snapshot({"bob": {"2026": 5}})
-
-    assert snap.exists()
+        save_snapshot({"bob": {"2026": 5}}, scope="abc123")
+    assert (nested / "snapshot-abc123.json").exists()
 
 
 def test_save_snapshot_persists_ranks(tmp_path):
-    snap = tmp_path / "snapshot.json"
-    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", snap):
-        with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
-            from ghsnitch.snapshot import save_snapshot
+    with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+        from ghsnitch.snapshot import save_snapshot
 
-            save_snapshot(
-                {"alice": {"2026": 100}},
-                ranks={"alice": 1},
-                positions={"alice": 1},
-            )
+        save_snapshot(
+            {"alice": {"2026": 100}},
+            ranks={"alice": 1},
+            positions={"alice": 1},
+            scope="abc123",
+        )
+    snap = tmp_path / "snapshot-abc123.json"
     data = json.loads(snap.read_text())
     assert data["ranks"] == {"alice": 1}
     assert data["positions"] == {"alice": 1}
 
 
 def test_save_snapshot_no_ranks_key_when_omitted(tmp_path):
-    snap = tmp_path / "snapshot.json"
-    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", snap):
-        with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
-            from ghsnitch.snapshot import save_snapshot
+    with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+        from ghsnitch.snapshot import save_snapshot
 
-            save_snapshot({"alice": {"2026": 100}})
+        save_snapshot({"alice": {"2026": 100}}, scope="abc123")
+    snap = tmp_path / "snapshot-abc123.json"
     data = json.loads(snap.read_text())
     assert "ranks" not in data
     assert "positions" not in data
 
 
 def test_save_snapshot_silently_ignores_os_error(tmp_path):
-    snap = tmp_path / "snapshot.json"
+    snap = tmp_path / "snapshot-abc123.json"
     snap.mkdir()  # make it a directory so write fails
-    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", snap):
-        with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
-            from ghsnitch.snapshot import save_snapshot
+    with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+        from ghsnitch.snapshot import save_snapshot
 
-            save_snapshot({"alice": {"2026": 10}})  # should not raise
+        save_snapshot({"alice": {"2026": 10}}, scope="abc123")  # should not raise
 
 
 # --- clear_snapshot ---
 
 
-def test_clear_snapshot_deletes_file(tmp_path):
-    snap = _make_snapshot_file(tmp_path, {"contributions": {}})
-    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", snap):
+def test_clear_snapshot_scoped_deletes_only_that_scope(tmp_path):
+    _make_snapshot_file(tmp_path, {"contributions": {}}, scope="aaa")
+    _make_snapshot_file(tmp_path, {"contributions": {}}, scope="bbb")
+    with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
+        from ghsnitch.snapshot import clear_snapshot
+
+        result = clear_snapshot(scope="aaa")
+    assert result is True
+    assert not (tmp_path / "snapshot-aaa.json").exists()
+    assert (tmp_path / "snapshot-bbb.json").exists()
+
+
+def test_clear_snapshot_no_scope_deletes_all(tmp_path):
+    _make_snapshot_file(tmp_path, {"contributions": {}}, scope="aaa")
+    _make_snapshot_file(tmp_path, {"contributions": {}}, scope="bbb")
+    _make_snapshot_file(tmp_path, {"contributions": {}})  # legacy
+    with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
         from ghsnitch.snapshot import clear_snapshot
 
         result = clear_snapshot()
     assert result is True
-    assert not snap.exists()
-
-
-def test_clear_snapshot_partitioned(tmp_path):
-    snap = _make_snapshot_file(
-        tmp_path, {"contributions": {}}, "snapshot-team-gamma.json"
-    )
-    with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
-        from ghsnitch.snapshot import clear_snapshot
-
-        result = clear_snapshot(context_id="team-gamma")
-    assert result is True
-    assert not snap.exists()
+    assert not (tmp_path / "snapshot-aaa.json").exists()
+    assert not (tmp_path / "snapshot-bbb.json").exists()
+    assert not (tmp_path / "snapshot.json").exists()
 
 
 def test_clear_snapshot_returns_true_when_no_file(tmp_path):
-    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", tmp_path / "snapshot.json"):
+    with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
         from ghsnitch.snapshot import clear_snapshot
 
-        assert clear_snapshot() is True
+        assert clear_snapshot(scope="nonexistent") is True
 
 
 def test_clear_snapshot_returns_false_on_os_error(tmp_path):
-    snap = tmp_path / "snapshot.json"
+    snap = tmp_path / "snapshot-abc123.json"
+    snap.write_text("{}")
 
     def _bad_unlink(*_args, **_kwargs):
         raise OSError("permission denied")
 
-    with patch("ghsnitch.snapshot._DEFAULT_SNAPSHOT_FILE", snap):
+    with patch("ghsnitch.snapshot.CACHE_DIR", tmp_path):
         with patch.object(Path, "unlink", _bad_unlink):
             from ghsnitch.snapshot import clear_snapshot
 
-            assert clear_snapshot() is False
+            assert clear_snapshot(scope="abc123") is False


### PR DESCRIPTION
## Problem

When switching between `--team` runs and default user runs, rank movement indicators recalculated incorrectly because the previous `context_id` approach used different snapshot keys for the same set of operatives:
- `--team quadra` → `snapshot-team-quadra.json`
- `--users alice,bob` (same users) → `snapshot-u-{hash}.json`

This meant rank positions were compared against different baselines depending on *how* users were specified, not *which* users were specified.

## Solution

Replace `context_id` with `compute_scope()` — a deterministic scope key derived from the **resolved user list** + `github_url`:
- `sha256(sorted_lowercase_usernames + "|" + github_url)[:12]`
- Same users always share a snapshot regardless of `--team` vs `--users`
- Case-insensitive (Alice == alice)
- Different GHE instances get separate scopes

### Key changes
- **snapshot.py**: Add `compute_scope()`, replace `context_id` with `scope` throughout. `clear_snapshot(scope=None)` now globs all snapshot files for `--reset-snapshot`.
- **cli.py**: Compute scope after all CLI overrides are applied, use unified `scope` parameter.
- **tests**: Full update of snapshot and CLI tests to use new scope-based API.

## Testing

- All 218 tests pass (`make test`)
- Lint clean (`make lint`)

Fixes #73