### PR TITLE
fix: prompt for confirmation and backup existing config on --init-config

### DIFF
--- a/src/ghsnitch/cli.py
+++ b/src/ghsnitch/cli.py
@@ -2,8 +2,10 @@ import hashlib
 import importlib.metadata
 import logging
 import math
+import shutil
 import sys
 import time
+from pathlib import Path
 
 import click
 import requests
@@ -21,7 +23,7 @@ from .api import (
     get_rolling_week_ranges,
     get_year_ranges,
 )
-from .config import generate_default_config, load_config
+from .config import generate_default_config, get_config_path, load_config
 from .logger import setup_logging
 from .snapshot import clear_snapshot, load_snapshot, save_snapshot
 from .ui import render_csv, render_json, render_markdown, render_table
@@ -259,6 +261,16 @@ def gh_snitch(  # noqa: PLR0913
     )
 
     if init_config:
+        path = Path(config) if config else get_config_path()
+        if path.exists():
+            click.confirm(
+                f"🚨 Operative config already exists at {path}. Overwrite and backup?",
+                abort=True,
+            )
+            backup = path.with_suffix(path.suffix + ".bak")
+            shutil.copy(path, backup)
+            click.echo(f"📦 Original dossier secured at: {backup}", err=True)
+
         path = generate_default_config(config)
         click.echo(f"🗂️  Handler config established at: {path}", err=True)
         return

--- a/src/ghsnitch/config.py
+++ b/src/ghsnitch/config.py
@@ -55,7 +55,8 @@ years = 3
 """
 
 
-def _default_config_path():
+def get_config_path():
+    """Return the default path for the configuration file."""
     return CONFIG_DIR / "config.toml"
 
 
@@ -65,7 +66,7 @@ def load_config(config_path=None):
     Returns dict with keys 'users', 'years', 'teams', and more.
     Warns (does not error) if the file is not found.
     """
-    path = Path(config_path) if config_path else _default_config_path()
+    path = Path(config_path) if config_path else get_config_path()
     config = {
         "users": [],
         "years": 3,
@@ -144,7 +145,7 @@ def load_config(config_path=None):
 
 def generate_default_config(config_path=None):
     """Write default config template to disk. Returns the path used."""
-    path = Path(config_path) if config_path else _default_config_path()
+    path = Path(config_path) if config_path else get_config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(_DEFAULT_CONFIG_TEMPLATE)
     return path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1280,3 +1280,51 @@ def test_team_snapshot_loaded_on_second_run(runner, tmp_path):
     assert "new" not in result2.output
     assert "  1   =   alice" in result2.output
     assert "  2   =   bob" in result2.output
+
+
+def test_init_config_aborts_if_declined(runner, tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("original content")
+
+    # input="n" to decline confirmation
+    result = runner.invoke(
+        gh_snitch, ["--init-config", "--config", str(config_path)], input="n\n"
+    )
+
+    assert result.exit_code != 0  # click.confirm(abort=True) exits non-zero on "n"
+    assert config_path.read_text() == "original content"
+    assert not (tmp_path / "config.toml.bak").exists()
+
+
+def test_init_config_overwrites_and_backups_if_confirmed(runner, tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("original content")
+
+    # input="y" to confirm overwrite
+    result = runner.invoke(
+        gh_snitch, ["--init-config", "--config", str(config_path)], input="y\n"
+    )
+
+    assert result.exit_code == 0
+    assert "secured" in result.output
+    assert "established" in result.output
+
+    # Verify backup exists and has original content
+    backup_path = tmp_path / "config.toml.bak"
+    assert backup_path.exists()
+    assert backup_path.read_text() == "original content"
+
+    # Verify main file is now the template
+    assert "gh-snitch configuration" in config_path.read_text()
+
+
+def test_init_config_no_prompt_if_missing(runner, tmp_path):
+    config_path = tmp_path / "new_config.toml"
+
+    # Should not prompt if file does not exist
+    result = runner.invoke(gh_snitch, ["--init-config", "--config", str(config_path)])
+
+    assert result.exit_code == 0
+    assert "established" in result.output
+    assert config_path.exists()
+    assert not (tmp_path / "new_config.toml.bak").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -160,7 +160,7 @@ wheels = [
 
 [[package]]
 name = "ghsnitch"
-version = "0.16.0"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #75. This PR adds a safety check to `--init-config`. If a configuration file already exists, the user is prompted for confirmation. If confirmed, a backup of the original file (e.g., `config.toml.bak`) is created before the new template is written.