### PR TITLE
feat: add --update-config and hide rank-delta by default

### DIFF
--- a/src/ghsnitch/cli.py
+++ b/src/ghsnitch/cli.py
@@ -11,6 +11,7 @@ import requests
 from rich.console import Console
 from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn
 
+from . import config as config_module
 from .api import (
     SECRET_GITHUB_TOKEN,
     VALID_PERIODS,
@@ -106,6 +107,16 @@ def _movement_delta(previous_position, current_position):
     return int(math.copysign(math.ceil(abs(raw_delta)), raw_delta))
 
 
+def _backup_config(path: Path):
+    """Create a backup of the config file, with timestamping if .bak exists."""
+    backup = path.with_suffix(path.suffix + ".bak")
+    if backup.exists():
+        timestamp = time.strftime("%Y%m%d-%H%M%S")
+        backup = path.with_suffix(f"{path.suffix}.{timestamp}.bak")
+    shutil.copy(path, backup)
+    return backup
+
+
 @click.command()
 @click.option("--config", default=None, help="Path to config file.")
 @click.option(
@@ -167,6 +178,12 @@ def _movement_delta(previous_position, current_position):
     help="Write a default config file and exit.",
 )
 @click.option(
+    "--update-config",
+    is_flag=True,
+    default=False,
+    help="Add missing keys from template to existing config and exit.",
+)
+@click.option(
     "--github-url",
     default=None,
     help="GitHub base URL (default: https://github.com). For GitHub Enterprise Server.",
@@ -202,6 +219,12 @@ def _movement_delta(previous_position, current_position):
     help="Annotate each cell with the operative's (N%) share of that year's total.",
 )
 @click.option(
+    "--rank-delta",
+    is_flag=True,
+    default=False,
+    help="Show a ± column with each operative's rank change since the last run.",
+)
+@click.option(
     "--delta",
     is_flag=True,
     default=False,
@@ -234,11 +257,13 @@ def gh_snitch(  # noqa: PLR0913
     github_url,
     show_config,
     init_config,
+    update_config,
     no_update_check,
     no_trend,
     min_contributions,
     totals,
     percent,
+    rank_delta,
     delta,
     reset_snapshot,
     output_format,
@@ -266,12 +291,33 @@ def gh_snitch(  # noqa: PLR0913
                 f"🚨 Operative config already exists at {path}. Overwrite and backup?",
                 abort=True,
             )
-            backup = path.with_suffix(path.suffix + ".bak")
-            shutil.copy(path, backup)
+            backup = _backup_config(path)
             click.echo(f"📦 Original dossier secured at: {backup}", err=True)
 
         path = generate_default_config(config)
         click.echo(f"🗂️  Handler config established at: {path}", err=True)
+        return
+
+    if update_config:
+        path = Path(config) if config else get_config_path()
+        if not path.exists():
+            click.echo(
+                f"🚨 No config file found at {path} to update. "
+                "Run with --init-config to create one.",
+                err=True,
+            )
+            sys.exit(1)
+
+        backup = _backup_config(path)
+        click.echo(f"🗂️  Backed up current dossier to {backup}", err=True)
+
+        added = config_module.update_config(config)
+        if added:
+            click.echo(f"✅  Added {len(added)} new keys to your config:", err=True)
+            for key in sorted(added):
+                click.echo(f"    {key}", err=True)
+        else:
+            click.echo("✅  Config is already up to date.", err=True)
         return
 
     cfg = load_config(config)
@@ -342,6 +388,8 @@ def gh_snitch(  # noqa: PLR0913
         cfg["totals"] = True
     if percent:
         cfg["percent"] = True
+    if rank_delta:
+        cfg["rank_delta"] = True
     if output_format is not None:
         cfg["output_format"] = output_format.lower()
 
@@ -535,6 +583,7 @@ def gh_snitch(  # noqa: PLR0913
             show_trend=not no_trend and delta_col is None and not suppress_trend,
             show_totals=show_totals,
             show_percent=cfg.get("percent", False),
+            show_rank_delta=cfg.get("rank_delta", False),
             delta_col=delta_col,
             rank_deltas=rank_deltas,
         )

--- a/src/ghsnitch/config.py
+++ b/src/ghsnitch/config.py
@@ -43,6 +43,9 @@ years = 3
 # Annotate each cell with the operative's percentage share of that year's total.
 # percent = false
 
+# Show a ± column with each operative's rank change since the last run.
+# rank_delta = false
+
 # Output format: table (default), json, csv, or markdown.
 # format = "table"
 
@@ -77,6 +80,7 @@ def load_config(config_path=None):
         "min_contributions": 0,
         "totals": False,
         "percent": False,
+        "rank_delta": False,
         "output_format": "table",
         "teams": {},
     }
@@ -124,6 +128,8 @@ def load_config(config_path=None):
         config["totals"] = bool(display["totals"])
     if "percent" in display:
         config["percent"] = bool(display["percent"])
+    if "rank_delta" in display:
+        config["rank_delta"] = bool(display["rank_delta"])
     if "format" in display:
         config["output_format"] = str(display["format"])
 
@@ -149,3 +155,107 @@ def generate_default_config(config_path=None):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(_DEFAULT_CONFIG_TEMPLATE)
     return path
+
+
+def update_config(config_path=None):
+    """Add missing keys from template to existing config.
+
+    Returns a list of keys added.
+    """
+    import re
+
+    path = Path(config_path) if config_path else get_config_path()
+    if not path.exists():
+        return []
+
+    # Use tomllib to find what's actually ACTIVE in current config
+    try:
+        with open(path, "rb") as f:
+            active_data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError):
+        active_data = {}
+
+    def get_all_keys(data, prefix=""):
+        keys = set()
+        for k, v in data.items():
+            full_key = f"{prefix}.{k}" if prefix else k
+            if isinstance(v, dict) and k != "teams":
+                keys.update(get_all_keys(v, full_key))
+            else:
+                keys.add(full_key)
+        return keys
+
+    active_keys = get_all_keys(active_data)
+    current_text = path.read_text()
+
+    # Also detect commented-out keys so we don't re-add them
+    commented_keys = set()
+    current_section = None
+    for line in current_text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        section_match = re.match(r"^\[([\w.]+)\]", line)
+        if section_match:
+            current_section = section_match.group(1)
+            continue
+        # Match # key = or key =
+        key_match = re.match(r"^(?:#\s*)?([\w-]+)\s*=", line)
+        if key_match and current_section:
+            commented_keys.add(f"{current_section}.{key_match.group(1)}")
+
+    existing_keys = active_keys | commented_keys
+
+    # Parse template to find all keys and their help blocks
+    added_keys = []
+    new_text = current_text
+
+    template_sections = re.split(r"\n(?=\[[\w.]+\])", _DEFAULT_CONFIG_TEMPLATE)
+    for section_block in template_sections:
+        section_match = re.search(r"^\[([\w.]+)\]", section_block, re.MULTILINE)
+        if not section_match:
+            continue
+        section_name = section_match.group(1)
+
+        # Find all keys in this template section
+        # Look for: # help text\n# key = value  OR  key = value
+        # This regex catches:
+        # 1. Any number of help/comment lines (Group 1)
+        # 2. An optional '# ' prefix for the key (Group 2)
+        # 3. The key name (Group 3)
+        # 4. The value (Group 4)
+        key_pattern = r"((?:# .*\n)*)(# )?([\w-]+)\s*=\s*(.*)"
+        for match in re.finditer(key_pattern, section_block):
+            help_text, _, key_name, default_val = match.groups()
+            full_key = f"{section_name}.{key_name}"
+
+            if full_key not in existing_keys:
+                # Add to existing config as a comment
+                addition = (
+                    f"\n# {help_text.strip()}\n# {key_name} = {default_val} "
+                    "(added by --update-config)\n"
+                )
+
+                section_header = f"[{section_name}]"
+                if section_header in new_text:
+                    # Append within section
+                    parts = re.split(rf"(\[{section_name}\])", new_text)
+                    # parts[2] is everything after [section]
+                    next_section_match = re.search(r"\n\[[\w.]+\]", parts[2])
+                    if next_section_match:
+                        pos = next_section_match.start()
+                        parts[2] = parts[2][:pos] + addition + parts[2][pos:]
+                    else:
+                        parts[2] = parts[2].rstrip() + "\n" + addition
+                    new_text = "".join(parts)
+                else:
+                    # Section missing
+                    new_text = new_text.rstrip() + f"\n\n[{section_name}]\n" + addition
+
+                added_keys.append(full_key)
+                existing_keys.add(full_key)
+
+    if added_keys:
+        path.write_text(new_text)
+
+    return added_keys

--- a/src/ghsnitch/ui.py
+++ b/src/ghsnitch/ui.py
@@ -387,6 +387,7 @@ def render_table(
     show_trend=True,
     show_totals=False,
     show_percent=False,
+    show_rank_delta=False,
     delta_col=None,
     rank_deltas=None,
 ):
@@ -439,7 +440,7 @@ def render_table(
                 for r in sorted_rows
             ]
 
-    show_rank_delta = rank_deltas is not None
+    show_rank_delta = show_rank_delta and rank_deltas is not None
     headers = (
         ["#"]
         + (["±"] if show_rank_delta else [])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -616,11 +616,11 @@ def test_rank_delta_marks_both_sides_when_tie_splits(runner, tmp_path):
                         [
                             "--config",
                             str(config_file),
+                            "--rank-delta",
                             "--no-update-check",
                             "--no-trend",
                         ],
                     )
-
     assert result.exit_code == 0
     assert "alice" in result.output
     assert "bob" in result.output
@@ -1229,6 +1229,7 @@ def test_team_snapshot_loaded_on_second_run(runner, tmp_path):
                             str(config_file),
                             "--team",
                             "alpha",
+                            "--rank-delta",
                             "--no-update-check",
                             "--no-trend",
                         ],
@@ -1247,11 +1248,11 @@ def test_team_snapshot_loaded_on_second_run(runner, tmp_path):
                             str(config_file),
                             "--team",
                             "alpha",
+                            "--rank-delta",
                             "--no-update-check",
                             "--no-trend",
                         ],
                     )
-
     assert result2.exit_code == 0
     # Both operatives should show "=" (rank unchanged), not "new".
     assert "new" not in result2.output
@@ -1305,3 +1306,98 @@ def test_init_config_no_prompt_if_missing(runner, tmp_path):
     assert "established" in result.output
     assert config_path.exists()
     assert not (tmp_path / "new_config.toml.bak").exists()
+
+
+def test_update_config_appends_missing_key(runner, tmp_path):
+    config_path = tmp_path / "config.toml"
+    # Create config missing rank_delta
+    config_path.write_text("[display]\ntotals = false\n")
+
+    result = runner.invoke(gh_snitch, ["--update-config", "--config", str(config_path)])
+
+    assert result.exit_code == 0
+    assert "Added" in result.output
+    assert "display.rank_delta" in result.output
+
+    content = config_path.read_text()
+    assert "[display]" in content
+    assert "totals = false" in content
+    assert "# rank_delta =" in content
+    assert "(added by --update-config)" in content
+
+
+def test_update_config_no_op_if_up_to_date(runner, tmp_path):
+    config_path = tmp_path / "config.toml"
+    # Write full template
+    from ghsnitch.config import generate_default_config
+
+    generate_default_config(str(config_path))
+
+    # Manually uncomment rank_delta so it exists
+    content = config_path.read_text().replace(
+        "# rank_delta = false", "rank_delta = true"
+    )
+    config_path.write_text(content)
+
+    result = runner.invoke(gh_snitch, ["--update-config", "--config", str(config_path)])
+
+    assert result.exit_code == 0
+    assert "already up to date" in result.output
+
+
+def test_update_config_backups_existing(runner, tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("old content")
+
+    runner.invoke(gh_snitch, ["--update-config", "--config", str(config_path)])
+
+    backup = tmp_path / "config.toml.bak"
+    assert backup.exists()
+    assert backup.read_text() == "old content"
+
+
+def test_update_config_missing_file_errors(runner, tmp_path):
+    config_path = tmp_path / "missing.toml"
+    result = runner.invoke(gh_snitch, ["--update-config", "--config", str(config_path)])
+
+    assert result.exit_code != 0
+    assert "No config file found" in result.output
+
+
+def test_rank_delta_column_hidden_by_default(runner, tmp_path, requests_mock):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text('[operatives]\nusers = ["alice"]\n')
+
+    # Mock response
+    requests_mock.post(
+        "https://api.github.com/graphql",
+        json={
+            "data": {
+                "user_alice": {
+                    "login": "alice",
+                    "contributionsCollection": {
+                        "contributionCalendar": {"totalContributions": 10}
+                    },
+                }
+            }
+        },
+    )
+
+    with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
+        with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
+            # Run once to create snapshot
+            runner.invoke(
+                gh_snitch, ["--config", str(config_file), "--no-update-check"]
+            )
+            # Run again — should NOT show ± by default
+            result = runner.invoke(
+                gh_snitch, ["--config", str(config_file), "--no-update-check"]
+            )
+            assert "±" not in result.output
+
+            # Run with --rank-delta — SHOULD show ±
+            result_with_delta = runner.invoke(
+                gh_snitch,
+                ["--config", str(config_file), "--rank-delta", "--no-update-check"],
+            )
+            assert "±" in result_with_delta.output

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -489,7 +489,9 @@ def test_rank_delta_cell_new_tty():
 def test_render_table_rank_delta_column_shown():
     rows = [{"username": "alice", "2025": 100}]
     with patch("ghsnitch.ui.IS_TTY", False):
-        output = render_table(rows, ["2025"], rank_deltas={"alice": 0})
+        output = render_table(
+            rows, ["2025"], show_rank_delta=True, rank_deltas={"alice": 0}
+        )
     assert "±" in output
 
 
@@ -506,7 +508,9 @@ def test_render_table_rank_delta_up_non_tty():
         {"username": "bob", "2025": 100},
     ]
     with patch("ghsnitch.ui.IS_TTY", False):
-        output = render_table(rows, ["2025"], rank_deltas={"alice": 2, "bob": -1})
+        output = render_table(
+            rows, ["2025"], show_rank_delta=True, rank_deltas={"alice": 2, "bob": -1}
+        )
     assert "+2" in output
     assert "-1" in output
 
@@ -514,14 +518,18 @@ def test_render_table_rank_delta_up_non_tty():
 def test_render_table_rank_delta_flat_non_tty():
     rows = [{"username": "alice", "2025": 100}]
     with patch("ghsnitch.ui.IS_TTY", False):
-        output = render_table(rows, ["2025"], rank_deltas={"alice": 0})
+        output = render_table(
+            rows, ["2025"], show_rank_delta=True, rank_deltas={"alice": 0}
+        )
     assert "=" in output
 
 
 def test_render_table_rank_delta_new_operative_non_tty():
     rows = [{"username": "alice", "2025": 100}]
     with patch("ghsnitch.ui.IS_TTY", False):
-        output = render_table(rows, ["2025"], rank_deltas={"alice": None})
+        output = render_table(
+            rows, ["2025"], show_rank_delta=True, rank_deltas={"alice": None}
+        )
     assert "new" in output
 
 
@@ -529,7 +537,11 @@ def test_render_table_rank_delta_with_totals():
     rows = [{"username": "alice", "2025": 100}]
     with patch("ghsnitch.ui.IS_TTY", False):
         output = render_table(
-            rows, ["2025"], show_totals=True, rank_deltas={"alice": 1}
+            rows,
+            ["2025"],
+            show_totals=True,
+            show_rank_delta=True,
+            rank_deltas={"alice": 1},
         )
     assert "±" in output
     assert "Total" in output

--- a/uv.lock
+++ b/uv.lock
@@ -160,7 +160,7 @@ wheels = [
 
 [[package]]
 name = "ghsnitch"
-version = "0.19.0"
+version = "0.19.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This PR addresses #50 and #49:\n\n1. **--update-config**: Adds a new flag to append missing keys from the default template to an existing config file as commented-out entries. Includes automatic timestamped backups.\n2. **rank-delta visibility**: The rank movement column (±) is now hidden by default and only shown when explicitly requested via the new `--rank-delta` flag or `rank_delta = true` in the config file.\n3. **config template**: Added `rank_delta` to the default configuration template.