### PR TITLE
refactor: replace asciichartpy with hand-rolled Unicode sparklines

### DIFF
--- a/docs/manual/usage.md
+++ b/docs/manual/usage.md
@@ -302,11 +302,11 @@ Render contribution data as a time-series line graph directly in the terminal:
 gh-snitch --users alice,bob --years 3 --format graph
 ```
 
-This provides a visual alternative to the ranked table, using `asciichartpy` to generate coloured trend lines.
+This provides a visual alternative to the ranked table. Each operative gets a colour-coded sparkline built from Unicode block characters (`▁▂▃▄▅▆▇█`), scaled relative to the top contributor, with numerical counts alongside.
 
-- **X-axis:** Time Period (chronological)
-- **Y-axis:** Contribution count
-- **Lines:** One line per operative, colour-coded
+- **Rows:** One sparkline row per operative, sorted by current-period activity
+- **Bars:** Block height reflects contribution level relative to the group maximum
+- **Colours:** Each operative's bar is colour-coded for quick identification
 
 It supports all time-period options:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
   "requests",
   "tabulate",
   "rich",
-  "asciichartpy",
 ]
 
 [project.scripts]

--- a/src/ghsnitch/ui.py
+++ b/src/ghsnitch/ui.py
@@ -6,7 +6,6 @@ import re
 import sys
 from datetime import datetime
 
-import asciichartpy as ac
 import tabulate as _tabulate_module
 from tabulate import tabulate
 
@@ -531,91 +530,75 @@ def render_table(
 
 
 def render_graph(rows, year_labels, show_totals=False):
-    """Render contribution data as a time-series line graph string."""
+    """Render contribution data as sparklines using Unicode block characters."""
     if not rows:
         return "(no operatives configured)"
 
-    # Time periods on X-axis, chronological order
     x_labels = list(reversed(year_labels))
-
-    # Sort rows by current-year count (descending) to match table order
     current_year_label = year_labels[0]
     sorted_rows = sorted(
         rows, key=lambda r: (-r.get(current_year_label, 0), r["username"])
     )
 
-    # Adjust graph size based on terminal or defaults
-    try:
-        width, height = os.get_terminal_size()
-        graph_height = max(10, min(height - 10, 20))
-        # Leave room for Y-axis labels and some margin
-        target_width = max(len(x_labels) * 4, width - 15)
-    except (OSError, AttributeError):
-        graph_height = 10
-        target_width = len(x_labels) * 4
-
-    # Interpolate data to stretch it horizontally
-    all_series = []
-    num_steps = len(x_labels)
-    if num_steps > 1 and target_width > num_steps:
-        for row in sorted_rows:
-            raw_series = [float(row.get(label, 0)) for label in x_labels]
-            interpolated = []
-            for j in range(target_width):
-                # Map j [0, target_width-1] to fractional index [0, num_steps-1]
-                idx = j * (num_steps - 1) / (target_width - 1)
-                left = int(idx)
-                right = min(left + 1, num_steps - 1)
-                frac = idx - left
-                val = raw_series[left] + frac * (raw_series[right] - raw_series[left])
-                interpolated.append(val)
-            all_series.append(interpolated)
-    else:
-        for row in sorted_rows:
-            series = [float(row.get(label, 0)) for label in x_labels]
-            all_series.append(series)
-
-    # Curate colors from asciichartpy
-    ac_colors = [
-        ac.lightcyan,
-        ac.lightmagenta,
-        ac.lightgreen,
-        ac.lightyellow,
-        ac.lightblue,
-        ac.lightred,
-        ac.cyan,
-        ac.magenta,
-        ac.green,
-        ac.yellow,
-        ac.blue,
-        ac.red,
+    ansi_colors = [
+        "\033[96m",  # bright cyan
+        "\033[95m",  # bright magenta
+        "\033[92m",  # bright green
+        "\033[93m",  # bright yellow
+        "\033[94m",  # bright blue
+        "\033[91m",  # bright red
+        "\033[36m",  # cyan
+        "\033[35m",  # magenta
+        "\033[32m",  # green
+        "\033[33m",  # yellow
+        "\033[34m",  # blue
+        "\033[31m",  # red
     ]
+    RESET = "\033[0m"
+    BLOCKS = " ▁▂▃▄▅▆▇█"
 
-    config = {
-        "height": graph_height,
-        "colors": [ac_colors[i % len(ac_colors)] for i in range(len(sorted_rows))],
-        "offset": 2,
-    }
+    all_values = [float(row.get(label, 0)) for row in sorted_rows for label in x_labels]
+    max_val = max(all_values) if all_values else 1.0
+    if max_val == 0.0:
+        max_val = 1.0
 
-    # Generate the plot
-    plot_output = ac.plot(all_series, config)
+    try:
+        term_width, _ = os.get_terminal_size()
+    except (OSError, AttributeError):
+        term_width = 80
 
-    # Construct the title and legend
+    num_periods = len(x_labels)
+    max_name_len = max(len(row["username"]) for row in sorted_rows)
+    vals_width = num_periods * 7
+    available = term_width - 2 - max_name_len - 4 - 2 - vals_width
+    chars_per_period = max(2, min(available // max(num_periods, 1), 12))
+    sparkline_width = chars_per_period * num_periods
+
     labels_str = " – ".join(x_labels)
     title = (
         "\n          🕵️  OPERATIVE SURVEILLANCE DOSSIER — "
         f"TREND ANALYSIS ({labels_str})\n"
     )
 
-    legend_items = []
-    reset = "\033[0m"
+    name_hdr = "Operative".ljust(max_name_len)
+    period_hdrs = "  ".join(lbl.rjust(6) for lbl in x_labels)
+    divider = "─" * (2 + max_name_len + 4 + sparkline_width + 2 + len(period_hdrs))
+    header = f"  {name_hdr}    {'':{sparkline_width}}  {period_hdrs}"
+
+    row_lines = []
     for i, row in enumerate(sorted_rows):
-        color_code = ac_colors[i % len(ac_colors)]
-        if not IS_TTY:
-            color_code = ""
-            reset = ""
-        legend_items.append(f"{color_code}{row['username']}{reset}")
+        name = row["username"].ljust(max_name_len)
+        bar = ""
+        for label in x_labels:
+            val = float(row.get(label, 0))
+            block_idx = round(val / max_val * 8)
+            bar += BLOCKS[block_idx] * chars_per_period
+        vals = "  ".join(str(int(row.get(label, 0))).rjust(6) for label in x_labels)
+        if IS_TTY:
+            c = ansi_colors[i % len(ansi_colors)]
+            row_lines.append(f"  {name}    {c}{bar}{RESET}  {vals}")
+        else:
+            row_lines.append(f"  {name}    {bar}  {vals}")
 
-    legend = "          " + ", ".join(legend_items) + "\n"
-
-    return f"{title}\n{plot_output}\n\n{legend}"
+    body = "\n".join(row_lines)
+    return f"{title}\n{header}\n  {divider}\n{body}\n"

--- a/uv.lock
+++ b/uv.lock
@@ -3,18 +3,6 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
-name = "asciichartpy"
-version = "1.5.25"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/41/3a/b01436be647f881515ec2f253616bf4a40c1d27d02a69e7f038e27fcdf81/asciichartpy-1.5.25.tar.gz", hash = "sha256:63a305302b2aad51da288b58226009b7b0313eba7d8e2452d5a21a13fcf44d74", size = 8201, upload-time = "2020-08-17T02:07:18.292Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/d0/7b958df957e4827837b590944008f0b28078f552b451f7407b4b3d54f574/asciichartpy-1.5.25-py2.py3-none-any.whl", hash = "sha256:33c417a3c8ef7d0a11b98eb9ea6dd9b2c1b17559e539b207a17d26d4302d0258", size = 7228, upload-time = "2020-08-17T02:07:16.386Z" },
-]
-
-[[package]]
 name = "black"
 version = "26.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -172,10 +160,9 @@ wheels = [
 
 [[package]]
 name = "ghsnitch"
-version = "0.21.0"
+version = "0.22.0"
 source = { editable = "." }
 dependencies = [
-    { name = "asciichartpy" },
     { name = "click" },
     { name = "requests" },
     { name = "rich" },
@@ -206,7 +193,6 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "asciichartpy" },
     { name = "black", marker = "extra == 'dev'" },
     { name = "black", marker = "extra == 'lint'" },
     { name = "click" },


### PR DESCRIPTION
Drops the unmaintained asciichartpy dependency (last released 2020) and
replaces the line-chart render_graph implementation with per-operative
sparkline rows using Unicode block characters (▁▂▃▄▅▆▇█). Each bar is
colour-coded via ANSI codes (same palette as before), scaled relative to
the group maximum, with numerical contribution counts alongside. Zero new
dependencies — Rich was already required.

Closes #80

https://claude.ai/code/session_019dDbc1YDTYtiua8jLNRp2m