### PR TITLE
feat: ghost operative detection for zero-activity users (#38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The table shows contribution counts per operative per year, colour-graded:
 - 🟢 Third quartile
 - 💚 Top quartile (bright green)
 - ⚪ Zero contributions (dim grey)
+- 👻 Ghost operative — zero contributions across all surveilled periods
 
 Operative names and counts are clickable hyperlinks in supporting terminals.
 

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -26,6 +26,16 @@
 | `--version` | — | Show version and exit |
 | `--help` | — | Show help and exit |
 
+## Automatic Indicators
+
+Some behaviours are always-on and require no flag:
+
+| Indicator | Condition | Output |
+|---|---|---|
+| 👻 / `[ghost]` | Operative has zero contributions across **all** surveilled windows | Appended to name in the Operative column; summary line on stderr |
+
+Ghost detection is suppressed in `--delta` mode.
+
 ## Environment Variables
 
 | Variable | Required | Description |

--- a/docs/manual/usage.md
+++ b/docs/manual/usage.md
@@ -149,6 +149,18 @@ gh-snitch --github-url https://github.example.com --users alice,bob
 
 The GraphQL API endpoint is derived automatically (`<host>/api/graphql`). Your `GITHUB_TOKEN` should be a personal access token issued by the Enterprise instance.
 
+## Ghost Operative Detection
+
+Operatives who have recorded zero contributions across **all** surveilled windows are automatically flagged as ghost operatives — dormant assets who have gone dark.
+
+In TTY mode a 👻 indicator is appended to the operative's name in the table. In non-TTY mode (pipes, scripts, `--format csv/json/markdown`) a `[ghost]` annotation is used instead. A summary line is also printed to stderr:
+
+```
+👻 1 ghost operative(s) detected — zero activity across all surveilled windows.
+```
+
+Ghost detection is automatic and requires no extra flags. It is suppressed in `--delta` mode, where the column shows contribution changes rather than totals.
+
 ## Filtering Inactive Operatives
 
 Suppress operatives whose current-year contribution count falls below a threshold:

--- a/src/ghsnitch/cli.py
+++ b/src/ghsnitch/cli.py
@@ -559,6 +559,13 @@ def gh_snitch(  # noqa: PLR0913
                 suppressed += 1
         rows = filtered_rows
 
+    # Detect ghost operatives: zero contributions across every surveilled window.
+    ghost_usernames = {
+        row["username"]
+        for row in rows
+        if all(row.get(lbl, 0) == 0 for lbl in year_labels)
+    }
+
     # Apply delta transformation if requested.
     delta_col = None
     if delta:
@@ -614,12 +621,20 @@ def gh_snitch(  # noqa: PLR0913
             show_rank_delta=cfg.get("rank_delta", True),
             delta_col=delta_col,
             rank_deltas=rank_deltas,
+            ghost_usernames=ghost_usernames if not delta else None,
         )
         click.echo(table)
 
     if suppressed > 0:
         click.echo(
             f"🔕 {suppressed} operative(s) below threshold suppressed.",
+            err=True,
+        )
+
+    if ghost_usernames:
+        click.echo(
+            f"👻 {len(ghost_usernames)} ghost operative(s) detected — "
+            "zero activity across all surveilled windows.",
             err=True,
         )
 

--- a/src/ghsnitch/ui.py
+++ b/src/ghsnitch/ui.py
@@ -83,10 +83,14 @@ def make_coloured_hyperlink_cell(count, url, column_values):
     return str(count)
 
 
-def make_operative_cell(username):
-    """Return a hyperlinked username cell."""
+def make_operative_cell(username, is_ghost=False):
+    """Return a hyperlinked username cell, with a ghost indicator if zero activity."""
     url = f"https://github.com/{username}"
-    return make_hyperlink(url, username)
+    link = make_hyperlink(url, username)
+    if not is_ghost:
+        return link
+    ghost_mark = " 👻" if IS_TTY else " [ghost]"
+    return link + ghost_mark
 
 
 # ---------------------------------------------------------------------------
@@ -391,6 +395,7 @@ def render_table(
     show_rank_delta=True,
     delta_col=None,
     rank_deltas=None,
+    ghost_usernames=None,
 ):
     """Render contribution data as a formatted table string.
 
@@ -409,6 +414,9 @@ def render_table(
             leaderboard movement since the previous run (positive = moved up,
             None = new operative). When provided, a ± column is shown after the
             # column.
+        ghost_usernames: optional set of usernames with zero contributions across all
+            surveilled periods. These operatives receive a 👻 (TTY) or [ghost]
+            (non-TTY) indicator appended to their name cell.
     """
     if not rows:
         return "(no operatives configured)"
@@ -465,11 +473,11 @@ def render_table(
     table_data = []
     for rank, row in zip(ranks, sorted_rows):
         username = row["username"]
-        profile_url = f"https://github.com/{username}"
         cells = [rank]
         if show_rank_delta:
             cells.append(_rank_delta_cell(rank_deltas.get(username)))
-        cells.append(make_hyperlink(profile_url, username))
+        is_ghost = ghost_usernames is not None and username in ghost_usernames
+        cells.append(make_operative_cell(username, is_ghost=is_ghost))
         if show_trend:
             current = row.get(year_labels[0], 0)
             previous = row.get(year_labels[1], 0)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -8,6 +8,7 @@ from ghsnitch.ui import (
     _rank_delta_cell,
     _trend_indicator,
     make_hyperlink,
+    make_operative_cell,
     render_csv,
     render_graph,
     render_json,
@@ -786,3 +787,72 @@ def test_render_graph_no_color():
             output = render_graph(rows, ["2026"])
     # ANSI escape sequences start with \033[
     assert "\033[" not in output
+
+
+# ---------------------------------------------------------------------------
+# Ghost operative indicator
+# ---------------------------------------------------------------------------
+
+
+def test_make_operative_cell_no_ghost():
+    with patch("ghsnitch.ui.IS_TTY", False):
+        result = make_operative_cell("alice", is_ghost=False)
+    assert result == "alice"
+    assert "ghost" not in result
+
+
+def test_make_operative_cell_ghost_non_tty():
+    with patch("ghsnitch.ui.IS_TTY", False):
+        result = make_operative_cell("alice", is_ghost=True)
+    assert "alice" in result
+    assert "[ghost]" in result
+
+
+def test_make_operative_cell_ghost_tty():
+    with patch("ghsnitch.ui.IS_TTY", True):
+        result = make_operative_cell("alice", is_ghost=True)
+    assert "alice" in result
+    assert "👻" in result
+
+
+def test_render_table_ghost_indicator_non_tty():
+    rows = [
+        {"username": "alice", "2025": 0, "2024": 0},
+        {"username": "bob", "2025": 100, "2024": 80},
+    ]
+    with patch("ghsnitch.ui.IS_TTY", False):
+        output = render_table(rows, ["2025", "2024"], ghost_usernames={"alice"})
+    alice_line = next(ln for ln in output.splitlines() if "alice" in ln)
+    bob_line = next(ln for ln in output.splitlines() if "bob" in ln)
+    assert "[ghost]" in alice_line
+    assert "[ghost]" not in bob_line
+
+
+def test_render_table_ghost_indicator_tty():
+    rows = [
+        {"username": "alice", "2025": 0},
+        {"username": "bob", "2025": 50},
+    ]
+    with patch("ghsnitch.ui.IS_TTY", True):
+        output = render_table(rows, ["2025"], ghost_usernames={"alice"})
+    assert "👻" in output
+
+
+def test_render_table_no_ghost_when_not_provided():
+    rows = [{"username": "alice", "2025": 0}]
+    with patch("ghsnitch.ui.IS_TTY", False):
+        output = render_table(rows, ["2025"])
+    assert "[ghost]" not in output
+    assert "👻" not in output
+
+
+def test_render_table_non_ghost_unaffected():
+    rows = [
+        {"username": "alice", "2025": 0},
+        {"username": "bob", "2025": 100},
+    ]
+    with patch("ghsnitch.ui.IS_TTY", False):
+        output = render_table(rows, ["2025"], ghost_usernames={"alice"})
+    # bob has contributions and must not get the ghost mark
+    bob_line = next(ln for ln in output.splitlines() if "bob" in ln)
+    assert "[ghost]" not in bob_line

--- a/uv.lock
+++ b/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "ghsnitch"
-version = "0.21.0"
+version = "0.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "asciichartpy" },


### PR DESCRIPTION
Operatives with zero contributions across all surveilled windows are now
flagged with a 👻 indicator (TTY) or [ghost] annotation (non-TTY) in the
Operative column. A summary line is printed to stderr when any ghosts are
detected. Ghost indicators are suppressed in --delta mode where contribution
deltas, not totals, are shown.

https://claude.ai/code/session_013Z95UmTrCjHztPhB8zrDXP