### PR TITLE
feat: --redact mode for shareable reports (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The table shows contribution counts per operative per year, colour-graded:
 - 🟢 Third quartile
 - 💚 Top quartile (bright green)
 - ⚪ Zero contributions (dim grey)
+- 👻 Ghost operative — zero contributions across all surveilled periods
 
 Operative names and counts are clickable hyperlinks in supporting terminals.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ make build
 | `--percent` | Annotate each cell with the operative's `(N%)` share of that year's total |
 | `--format` | Output format: `table` (default), `json`, `csv`, `markdown`, `graph` |
 | `--no-rank-delta` | Hide the `±` rank-change column (shown by default) |
+| `--redact` | Replace operative usernames with NATO phonetic codenames (Operative Alpha, Bravo, …) for shareable reports |
 | `--delta` | Show change since last snapshot instead of current-year count |
 | `--reset-snapshot` | Clear the saved contribution snapshot and exit |
 | `--config` | Path to config file |

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -26,6 +26,16 @@
 | `--version` | — | Show version and exit |
 | `--help` | — | Show help and exit |
 
+## Automatic Indicators
+
+Some behaviours are always-on and require no flag:
+
+| Indicator | Condition | Output |
+|---|---|---|
+| 👻 / `[ghost]` | Operative has zero contributions across **all** surveilled windows | Appended to name in the Operative column; summary line on stderr |
+
+Ghost detection is suppressed in `--delta` mode.
+
 ## Environment Variables
 
 | Variable | Required | Description |

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -17,6 +17,7 @@
 | `--percent` | off | Annotate each contribution cell with the operative's `(N%)` share of that year's total; percentages are colour-graded in TTY mode |
 | `--format TEXT` | `table` (from config) | Output format: `table`, `json`, `csv`, `markdown`, or `graph`. Non-table formats write clean data to stdout and send status messages to stderr. |
 | `--no-rank-delta` | off | Hide the `±` rank-change column (rank delta is shown by default) |
+| `--redact` | off | Replace operative usernames with NATO phonetic codenames (Operative Alpha, Bravo, …); suppresses hyperlinks. Codenames are assigned in alphabetical order of the real username and are deterministic across runs. Works with all output formats. |
 | `--delta` | off | Replace the current-year column with `Δ Today` showing the change since the last saved snapshot; green/red-coded |
 | `--reset-snapshot` | off | Clear the saved contribution snapshot and exit |
 | `--no-trend` | off | Hide the Trend column |

--- a/docs/manual/usage.md
+++ b/docs/manual/usage.md
@@ -161,6 +161,37 @@ In TTY mode a 👻 indicator is appended to the operative's name in the table. I
 
 Ghost detection is automatic and requires no extra flags. It is suppressed in `--delta` mode, where the column shows contribution changes rather than totals.
 
+## Redacting Operative Identities
+
+Use `--redact` to replace real GitHub usernames with NATO phonetic codenames before output is rendered. This lets you share reports publicly without exposing team members' handles.
+
+```bash
+gh-snitch --users alice,bob,carol --redact
+```
+
+```
+#  Operative          2026   2025   2024
+1  Operative Bravo     412    380    310
+2  Operative Alpha     210    195    180
+3  Operative Charlie   170    210    190
+```
+
+Codenames are assigned in alphabetical order of the real username, so the mapping is stable across runs:
+
+| Real handle | Codename            |
+|-------------|---------------------|
+| alice       | Operative Alpha     |
+| bob         | Operative Bravo     |
+| carol       | Operative Charlie   |
+
+If you have more than 26 operatives the sequence continues as Operative Alpha-2, Bravo-2, etc.
+
+In redact mode:
+- OSC 8 terminal hyperlinks are suppressed — no clickable links that could reveal the real handle
+- The codename replaces the username in all output formats (`table`, `json`, `csv`, `markdown`, `graph`)
+- Ghost indicators (`👻` / `[ghost]`) are still shown alongside the codename
+- Error messages for not-found operatives also use the codename
+
 ## Filtering Inactive Operatives
 
 Suppress operatives whose current-year contribution count falls below a threshold:

--- a/docs/manual/usage.md
+++ b/docs/manual/usage.md
@@ -149,6 +149,18 @@ gh-snitch --github-url https://github.example.com --users alice,bob
 
 The GraphQL API endpoint is derived automatically (`<host>/api/graphql`). Your `GITHUB_TOKEN` should be a personal access token issued by the Enterprise instance.
 
+## Ghost Operative Detection
+
+Operatives who have recorded zero contributions across **all** surveilled windows are automatically flagged as ghost operatives — dormant assets who have gone dark.
+
+In TTY mode a 👻 indicator is appended to the operative's name in the table. In non-TTY mode (pipes, scripts, `--format csv/json/markdown`) a `[ghost]` annotation is used instead. A summary line is also printed to stderr:
+
+```
+👻 1 ghost operative(s) detected — zero activity across all surveilled windows.
+```
+
+Ghost detection is automatic and requires no extra flags. It is suppressed in `--delta` mode, where the column shows contribution changes rather than totals.
+
 ## Filtering Inactive Operatives
 
 Suppress operatives whose current-year contribution count falls below a threshold:

--- a/src/ghsnitch/cli.py
+++ b/src/ghsnitch/cli.py
@@ -37,6 +37,35 @@ from .updater import check_for_update
 
 VALID_FORMATS = ("table", "json", "csv", "markdown", "graph")
 
+_NATO_ALPHABET = [
+    "Alpha",
+    "Bravo",
+    "Charlie",
+    "Delta",
+    "Echo",
+    "Foxtrot",
+    "Golf",
+    "Hotel",
+    "India",
+    "Juliet",
+    "Kilo",
+    "Lima",
+    "Mike",
+    "November",
+    "Oscar",
+    "Papa",
+    "Quebec",
+    "Romeo",
+    "Sierra",
+    "Tango",
+    "Uniform",
+    "Victor",
+    "Whiskey",
+    "X-ray",
+    "Yankee",
+    "Zulu",
+]
+
 logger = logging.getLogger(__name__)
 
 
@@ -231,6 +260,12 @@ def _backup_config(path: Path):
     help="Hide the ± column showing rank change since the last run.",
 )
 @click.option(
+    "--redact",
+    is_flag=True,
+    default=False,
+    help="Replace operative usernames with NATO codenames for shareable output.",
+)
+@click.option(
     "--delta",
     is_flag=True,
     default=False,
@@ -270,6 +305,7 @@ def gh_snitch(  # noqa: PLR0913
     totals,
     percent,
     no_rank_delta,
+    redact,
     delta,
     reset_snapshot,
     output_format,
@@ -364,6 +400,13 @@ def gh_snitch(  # noqa: PLR0913
         cfg["users"] = teams[team]
 
     operative_list = cfg["users"]
+
+    # Build redact map: sorted usernames → NATO codenames (deterministic).
+    redact_map: dict[str, str] = {}
+    if redact:
+        for i, username in enumerate(sorted(operative_list)):
+            suffix = f"-{i // 26 + 1}" if i >= 26 else ""
+            redact_map[username] = f"Operative {_NATO_ALPHABET[i % 26]}{suffix}"
 
     # Calculate context ID for partitioned snapshot caching.
     context_id = None
@@ -592,12 +635,22 @@ def gh_snitch(  # noqa: PLR0913
 
     show_totals = cfg.get("totals", False)
 
+    _redact = redact_map or None
     if active_format == "json":
-        click.echo(render_json(rows, year_labels, show_totals=show_totals))
+        click.echo(
+            render_json(rows, year_labels, show_totals=show_totals, redact_map=_redact)
+        )
     elif active_format == "csv":
-        click.echo(render_csv(rows, year_labels, show_totals=show_totals), nl=False)
+        click.echo(
+            render_csv(rows, year_labels, show_totals=show_totals, redact_map=_redact),
+            nl=False,
+        )
     elif active_format == "markdown":
-        click.echo(render_markdown(rows, year_labels, show_totals=show_totals))
+        click.echo(
+            render_markdown(
+                rows, year_labels, show_totals=show_totals, redact_map=_redact
+            )
+        )
     elif active_format == "graph":
         if cfg.get("percent"):
             click.echo(
@@ -609,7 +662,9 @@ def gh_snitch(  # noqa: PLR0913
                 "⚠️  --totals is ignored in graph format (no footer rows in charts).",
                 err=True,
             )
-        click.echo(render_graph(rows, year_labels, show_totals=show_totals))
+        click.echo(
+            render_graph(rows, year_labels, show_totals=show_totals, redact_map=_redact)
+        )
     else:
         table = render_table(
             rows,
@@ -622,6 +677,7 @@ def gh_snitch(  # noqa: PLR0913
             delta_col=delta_col,
             rank_deltas=rank_deltas,
             ghost_usernames=ghost_usernames if not delta else None,
+            redact_map=_redact,
         )
         click.echo(table)
 
@@ -640,8 +696,9 @@ def gh_snitch(  # noqa: PLR0913
 
     if not_found:
         for username in sorted(not_found):
+            display = redact_map.get(username, username) if redact_map else username
             click.echo(
-                f"⚠️  Operative '{username}' not found — they may have gone dark.",
+                f"⚠️  Operative '{display}' not found — they may have gone dark.",
                 err=True,
             )
         click.echo(

--- a/src/ghsnitch/cli.py
+++ b/src/ghsnitch/cli.py
@@ -559,6 +559,13 @@ def gh_snitch(  # noqa: PLR0913
                 suppressed += 1
         rows = filtered_rows
 
+    # Detect ghost operatives: zero contributions across every surveilled window.
+    ghost_usernames = {
+        row["username"]
+        for row in rows
+        if all(row.get(lbl, 0) == 0 for lbl in year_labels)
+    }
+
     # Apply delta transformation if requested.
     delta_col = None
     if delta:
@@ -614,12 +621,20 @@ def gh_snitch(  # noqa: PLR0913
             show_rank_delta=cfg.get("rank_delta", True),
             delta_col=delta_col,
             rank_deltas=rank_deltas,
+            ghost_usernames=ghost_usernames if not delta else None,
         )
         click.echo(table)
 
     if suppressed > 0:
         click.echo(
             f"🔕 {suppressed} operative(s) below threshold suppressed.",
+            err=True,
+        )
+
+    if ghost_usernames:
+        click.echo(
+            f"👻 {len(ghost_usernames)} ghost operative(s) detected — "
+            "zero activity across all surveilled windows.",
             err=True,
         )
 

--- a/src/ghsnitch/ui.py
+++ b/src/ghsnitch/ui.py
@@ -506,7 +506,8 @@ def render_table(
             count = row.get(label, 0)
             if label == delta_col:
                 cells.append(_delta_cell(count, col_values[label]))
-            elif redact_map is not None:
+                continue
+            if redact_map is not None:
                 if IS_TTY:
                     prefix, suffix = _grade_colour(count, col_values[label])
                     cell = f"{prefix}{count}{suffix}"
@@ -517,16 +518,16 @@ def render_table(
                 cell = make_coloured_hyperlink_cell(
                     count, contrib_url, col_values[label]
                 )
-                if show_percent:
-                    total = year_totals[label]
-                    pct = (count / total * 100) if total > 0 else 0.0
-                    if IS_TTY:
-                        prefix, suffix = _grade_colour(pct, col_pct_values[label])
-                        pct_annotation = f"({prefix}{pct:.0f}%{suffix})"
-                    else:
-                        pct_annotation = f"({pct:.0f}%)"
-                    cell = f"{cell} {pct_annotation}"
-                cells.append(cell)
+            if show_percent:
+                total = year_totals[label]
+                pct = (count / total * 100) if total > 0 else 0.0
+                if IS_TTY:
+                    prefix, suffix = _grade_colour(pct, col_pct_values[label])
+                    pct_annotation = f"({prefix}{pct:.0f}%{suffix})"
+                else:
+                    pct_annotation = f"({pct:.0f}%)"
+                cell = f"{cell} {pct_annotation}"
+            cells.append(cell)
         if show_totals:
             cells.append(sum(row.get(label, 0) for label in year_labels))
         table_data.append(cells)

--- a/src/ghsnitch/ui.py
+++ b/src/ghsnitch/ui.py
@@ -83,10 +83,14 @@ def make_coloured_hyperlink_cell(count, url, column_values):
     return str(count)
 
 
-def make_operative_cell(username):
-    """Return a hyperlinked username cell."""
+def make_operative_cell(username, is_ghost=False):
+    """Return a hyperlinked username cell, with a ghost indicator if zero activity."""
     url = f"https://github.com/{username}"
-    return make_hyperlink(url, username)
+    link = make_hyperlink(url, username)
+    if not is_ghost:
+        return link
+    ghost_mark = " 👻" if IS_TTY else " [ghost]"
+    return link + ghost_mark
 
 
 # ---------------------------------------------------------------------------
@@ -391,6 +395,7 @@ def render_table(
     show_rank_delta=True,
     delta_col=None,
     rank_deltas=None,
+    ghost_usernames=None,
 ):
     """Render contribution data as a formatted table string.
 
@@ -409,6 +414,9 @@ def render_table(
             leaderboard movement since the previous run (positive = moved up,
             None = new operative). When provided, a ± column is shown after the
             # column.
+        ghost_usernames: optional set of usernames with zero contributions across all
+            surveilled periods. These operatives receive a 👻 (TTY) or [ghost]
+            (non-TTY) indicator appended to their name cell.
     """
     if not rows:
         return "(no operatives configured)"
@@ -465,11 +473,11 @@ def render_table(
     table_data = []
     for rank, row in zip(ranks, sorted_rows):
         username = row["username"]
-        profile_url = f"https://github.com/{username}"
         cells = [rank]
         if show_rank_delta:
             cells.append(_rank_delta_cell(rank_deltas.get(username)))
-        cells.append(make_hyperlink(profile_url, username))
+        is_ghost = ghost_usernames is not None and username in ghost_usernames
+        cells.append(make_operative_cell(username, is_ghost=is_ghost))
         if show_trend:
             current = row.get(year_labels[0], 0)
             previous = row.get(year_labels[1], 0)

--- a/src/ghsnitch/ui.py
+++ b/src/ghsnitch/ui.py
@@ -83,8 +83,15 @@ def make_coloured_hyperlink_cell(count, url, column_values):
     return str(count)
 
 
-def make_operative_cell(username, is_ghost=False):
-    """Return a hyperlinked username cell, with a ghost indicator if zero activity."""
+def make_operative_cell(username, is_ghost=False, display_name=None):
+    """Return an operative name cell.
+
+    When display_name is provided (redact mode) the cell is plain text with no
+    hyperlink.  Otherwise a clickable OSC 8 link to the GitHub profile is used.
+    """
+    if display_name is not None:
+        ghost_mark = (" 👻" if IS_TTY else " [ghost]") if is_ghost else ""
+        return display_name + ghost_mark
     url = f"https://github.com/{username}"
     link = make_hyperlink(url, username)
     if not is_ghost:
@@ -290,7 +297,7 @@ def _sorted_rows_and_ranks(rows, year_labels):
     return sorted_rows, ranks
 
 
-def render_json(rows, year_labels, show_totals=False):
+def render_json(rows, year_labels, show_totals=False, redact_map=None):
     """Render contribution data as a JSON array (no ANSI codes).
 
     Each element is an object with "rank", "operative", one key per period
@@ -301,7 +308,9 @@ def render_json(rows, year_labels, show_totals=False):
     sorted_rows, ranks = _sorted_rows_and_ranks(rows, year_labels)
     result = []
     for rank, row in zip(ranks, sorted_rows):
-        entry = {"rank": rank, "operative": row["username"]}
+        username = row["username"]
+        operative_name = redact_map.get(username, username) if redact_map else username
+        entry = {"rank": rank, "operative": operative_name}
         for label in year_labels:
             entry[label] = row.get(label, 0)
         if show_totals:
@@ -310,7 +319,7 @@ def render_json(rows, year_labels, show_totals=False):
     return _json.dumps(result, indent=2, ensure_ascii=False)
 
 
-def render_csv(rows, year_labels, show_totals=False):
+def render_csv(rows, year_labels, show_totals=False, redact_map=None):
     """Render contribution data as CSV (no ANSI codes).
 
     Header row: rank, operative, <period labels…> [, total]
@@ -326,7 +335,9 @@ def render_csv(rows, year_labels, show_totals=False):
     writer = _csv.DictWriter(output, fieldnames=fieldnames)
     writer.writeheader()
     for rank, row in zip(ranks, sorted_rows):
-        record = {"rank": rank, "operative": row["username"]}
+        username = row["username"]
+        operative_name = redact_map.get(username, username) if redact_map else username
+        record = {"rank": rank, "operative": operative_name}
         for label in year_labels:
             record[label] = row.get(label, 0)
         if show_totals:
@@ -344,7 +355,7 @@ def render_csv(rows, year_labels, show_totals=False):
     return output.getvalue()
 
 
-def render_markdown(rows, year_labels, show_totals=False):
+def render_markdown(rows, year_labels, show_totals=False, redact_map=None):
     """Render contribution data as a GitHub-Flavoured Markdown table (no ANSI).
 
     Columns: # | Operative | <period labels…> [| Total]
@@ -365,7 +376,9 @@ def render_markdown(rows, year_labels, show_totals=False):
 
     lines = [_row(headers), separator]
     for rank, row in zip(ranks, sorted_rows):
-        cells = [rank, row["username"]]
+        username = row["username"]
+        operative_name = redact_map.get(username, username) if redact_map else username
+        cells = [rank, operative_name]
         for label in year_labels:
             cells.append(row.get(label, 0))
         if show_totals:
@@ -396,6 +409,7 @@ def render_table(
     delta_col=None,
     rank_deltas=None,
     ghost_usernames=None,
+    redact_map=None,
 ):
     """Render contribution data as a formatted table string.
 
@@ -417,6 +431,9 @@ def render_table(
         ghost_usernames: optional set of usernames with zero contributions across all
             surveilled periods. These operatives receive a 👻 (TTY) or [ghost]
             (non-TTY) indicator appended to their name cell.
+        redact_map: optional dict mapping real usernames to NATO codenames. When
+            provided, the codename replaces the username in the Operative column
+            and no hyperlink is emitted (plain text only).
     """
     if not rows:
         return "(no operatives configured)"
@@ -477,7 +494,10 @@ def render_table(
         if show_rank_delta:
             cells.append(_rank_delta_cell(rank_deltas.get(username)))
         is_ghost = ghost_usernames is not None and username in ghost_usernames
-        cells.append(make_operative_cell(username, is_ghost=is_ghost))
+        display_name = redact_map.get(username) if redact_map else None
+        cells.append(
+            make_operative_cell(username, is_ghost=is_ghost, display_name=display_name)
+        )
         if show_trend:
             current = row.get(year_labels[0], 0)
             previous = row.get(year_labels[1], 0)
@@ -486,6 +506,12 @@ def render_table(
             count = row.get(label, 0)
             if label == delta_col:
                 cells.append(_delta_cell(count, col_values[label]))
+            elif redact_map is not None:
+                if IS_TTY:
+                    prefix, suffix = _grade_colour(count, col_values[label])
+                    cell = f"{prefix}{count}{suffix}"
+                else:
+                    cell = str(count)
             else:
                 contrib_url = f"https://github.com/{username}"
                 cell = make_coloured_hyperlink_cell(
@@ -538,7 +564,7 @@ def render_table(
     )
 
 
-def render_graph(rows, year_labels, show_totals=False):
+def render_graph(rows, year_labels, show_totals=False, redact_map=None):
     """Render contribution data as a time-series line graph string."""
     if not rows:
         return "(no operatives configured)"
@@ -622,7 +648,12 @@ def render_graph(rows, year_labels, show_totals=False):
         if not IS_TTY:
             color_code = ""
             reset = ""
-        legend_items.append(f"{color_code}{row['username']}{reset}")
+        name = (
+            redact_map.get(row["username"], row["username"])
+            if redact_map
+            else row["username"]
+        )
+        legend_items.append(f"{color_code}{name}{reset}")
 
     legend = "          " + ", ".join(legend_items) + "\n"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1301,22 +1301,7 @@ def test_rank_delta_column_visible_by_default(runner, tmp_path, requests_mock):
 # --redact mode
 # ---------------------------------------------------------------------------
 
-_GRAPHQL_RESPONSE_TWO_USERS = {
-    "data": {
-        "user_alice": {
-            "login": "alice",
-            "contributionsCollection": {
-                "contributionCalendar": {"totalContributions": 100}
-            },
-        },
-        "user_bob": {
-            "login": "bob",
-            "contributionsCollection": {
-                "contributionCalendar": {"totalContributions": 50}
-            },
-        },
-    }
-}
+_GRAPHQL_RESPONSE_TWO_USERS = _graphql_response(("alice", 100), ("bob", 50))
 
 
 def _make_two_user_config(tmp_path, years=0):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1400,3 +1400,103 @@ def test_rank_delta_column_visible_by_default(runner, tmp_path, requests_mock):
                     ],
                 )
                 assert "±" not in result_no_delta.output
+
+
+# ---------------------------------------------------------------------------
+# --redact mode
+# ---------------------------------------------------------------------------
+
+_GRAPHQL_RESPONSE_TWO_USERS = {
+    "data": {
+        "user_alice": {
+            "login": "alice",
+            "contributionsCollection": {
+                "contributionCalendar": {"totalContributions": 100}
+            },
+        },
+        "user_bob": {
+            "login": "bob",
+            "contributionsCollection": {
+                "contributionCalendar": {"totalContributions": 50}
+            },
+        },
+    }
+}
+
+
+def _make_two_user_config(tmp_path, years=0):
+    f = tmp_path / "config.toml"
+    f.write_text(
+        f'[operatives]\nusers = ["alice", "bob"]\n[surveillance]\nyears = {years}\n'
+    )
+    return f
+
+
+def test_redact_replaces_usernames(runner, tmp_path, requests_mock):
+    requests_mock.post(
+        "https://api.github.com/graphql", json=_GRAPHQL_RESPONSE_TWO_USERS
+    )
+    cfg = _make_two_user_config(tmp_path)
+    result = _run(runner, cfg, tmp_path, ["--redact"])
+    assert result.exit_code == 0
+    assert "alice" not in result.output
+    assert "bob" not in result.output
+
+
+def test_redact_uses_nato_codenames(runner, tmp_path, requests_mock):
+    requests_mock.post(
+        "https://api.github.com/graphql", json=_GRAPHQL_RESPONSE_TWO_USERS
+    )
+    cfg = _make_two_user_config(tmp_path)
+    result = _run(runner, cfg, tmp_path, ["--redact"])
+    assert result.exit_code == 0
+    # alice sorts before bob → Operative Alpha; bob → Operative Bravo
+    assert "Operative Alpha" in result.output
+    assert "Operative Bravo" in result.output
+
+
+def test_redact_codename_order_is_deterministic(runner, tmp_path, requests_mock):
+    requests_mock.post(
+        "https://api.github.com/graphql", json=_GRAPHQL_RESPONSE_TWO_USERS
+    )
+    cfg = _make_two_user_config(tmp_path)
+    result1 = _run(runner, cfg, tmp_path, ["--redact", "--no-rank-delta"])
+    result2 = _run(runner, cfg, tmp_path, ["--redact", "--no-rank-delta"])
+    assert result1.output == result2.output
+
+
+def test_redact_json_format_uses_codenames(runner, tmp_path, requests_mock):
+    requests_mock.post(
+        "https://api.github.com/graphql", json=_GRAPHQL_RESPONSE_TWO_USERS
+    )
+    cfg = _make_two_user_config(tmp_path)
+    result = _run(runner, cfg, tmp_path, ["--redact", "--format", "json"])
+    assert result.exit_code == 0
+    data = _extract_json(result.output)
+    operatives = {e["operative"] for e in data}
+    assert "Operative Alpha" in operatives
+    assert "Operative Bravo" in operatives
+    assert not any(o in ("alice", "bob") for o in operatives)
+
+
+def test_redact_csv_format_uses_codenames(runner, tmp_path, requests_mock):
+    requests_mock.post(
+        "https://api.github.com/graphql", json=_GRAPHQL_RESPONSE_TWO_USERS
+    )
+    cfg = _make_two_user_config(tmp_path)
+    result = _run(runner, cfg, tmp_path, ["--redact", "--format", "csv"])
+    assert result.exit_code == 0
+    assert "Operative" in result.output
+    assert "alice" not in result.output
+    assert "bob" not in result.output
+
+
+def test_redact_markdown_format_uses_codenames(runner, tmp_path, requests_mock):
+    requests_mock.post(
+        "https://api.github.com/graphql", json=_GRAPHQL_RESPONSE_TWO_USERS
+    )
+    cfg = _make_two_user_config(tmp_path)
+    result = _run(runner, cfg, tmp_path, ["--redact", "--format", "markdown"])
+    assert result.exit_code == 0
+    assert "Operative Alpha" in result.output
+    assert "alice" not in result.output

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -952,3 +952,72 @@ def test_render_table_redact_unmapped_shows_username():
         output = render_table(rows, ["2025"], redact_map={"alice": "Operative Alpha"})
     assert "Operative Alpha" in output
     assert "unknown" in output
+
+
+def test_render_table_redact_shows_year_columns():
+    """Year data must appear in all columns — not just the operative name."""
+    rows = [
+        {"username": "alice", "2024": 80, "2025": 100},
+        {"username": "bob", "2024": 40, "2025": 50},
+    ]
+    with patch("ghsnitch.ui.IS_TTY", False):
+        output = render_table(
+            rows,
+            ["2025", "2024"],
+            redact_map={"alice": "Operative Alpha", "bob": "Operative Bravo"},
+        )
+    assert "100" in output
+    assert "80" in output
+    assert "50" in output
+    assert "40" in output
+    assert "alice" not in output
+    assert "bob" not in output
+
+
+def test_render_table_redact_with_percent():
+    """--percent annotations must appear in redact mode."""
+    rows = [{"username": "alice", "2025": 100}, {"username": "bob", "2025": 100}]
+    with patch("ghsnitch.ui.IS_TTY", False):
+        output = render_table(
+            rows,
+            ["2025"],
+            show_percent=True,
+            redact_map={"alice": "Operative Alpha", "bob": "Operative Bravo"},
+        )
+    assert "50%" in output
+
+
+def test_render_table_redact_with_totals():
+    """--totals footer and per-row Total column must appear in redact mode."""
+    rows = [{"username": "alice", "2024": 80, "2025": 100}]
+    with patch("ghsnitch.ui.IS_TTY", False):
+        output = render_table(
+            rows,
+            ["2025", "2024"],
+            show_totals=True,
+            redact_map={"alice": "Operative Alpha"},
+        )
+    assert "180" in output  # per-row total
+    assert "Total" in output
+
+
+def test_render_graph_redact_uses_codenames_in_legend():
+    """Graph legend must show codenames, not real usernames."""
+    rows = [
+        {"username": "alice", "2024": 80, "2025": 100},
+        {"username": "bob", "2024": 40, "2025": 50},
+    ]
+    with patch("ghsnitch.ui.IS_TTY", False):
+        with patch(
+            "os.get_terminal_size",
+            return_value=__import__("os").terminal_size((80, 24)),
+        ):  # noqa: E501
+            output = render_graph(
+                rows,
+                ["2025", "2024"],
+                redact_map={"alice": "Operative Alpha", "bob": "Operative Bravo"},
+            )
+    assert "Operative Alpha" in output
+    assert "Operative Bravo" in output
+    assert "alice" not in output
+    assert "bob" not in output

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -8,6 +8,7 @@ from ghsnitch.ui import (
     _rank_delta_cell,
     _trend_indicator,
     make_hyperlink,
+    make_operative_cell,
     render_csv,
     render_graph,
     render_json,
@@ -786,3 +787,72 @@ def test_render_graph_no_color():
             output = render_graph(rows, ["2026"])
     # ANSI escape sequences start with \033[
     assert "\033[" not in output
+
+
+# ---------------------------------------------------------------------------
+# Ghost operative indicator
+# ---------------------------------------------------------------------------
+
+
+def test_make_operative_cell_no_ghost():
+    with patch("ghsnitch.ui.IS_TTY", False):
+        result = make_operative_cell("alice", is_ghost=False)
+    assert result == "alice"
+    assert "ghost" not in result
+
+
+def test_make_operative_cell_ghost_non_tty():
+    with patch("ghsnitch.ui.IS_TTY", False):
+        result = make_operative_cell("alice", is_ghost=True)
+    assert "alice" in result
+    assert "[ghost]" in result
+
+
+def test_make_operative_cell_ghost_tty():
+    with patch("ghsnitch.ui.IS_TTY", True):
+        result = make_operative_cell("alice", is_ghost=True)
+    assert "alice" in result
+    assert "👻" in result
+
+
+def test_render_table_ghost_indicator_non_tty():
+    rows = [
+        {"username": "alice", "2025": 0, "2024": 0},
+        {"username": "bob", "2025": 100, "2024": 80},
+    ]
+    with patch("ghsnitch.ui.IS_TTY", False):
+        output = render_table(rows, ["2025", "2024"], ghost_usernames={"alice"})
+    alice_line = next(ln for ln in output.splitlines() if "alice" in ln)
+    bob_line = next(ln for ln in output.splitlines() if "bob" in ln)
+    assert "[ghost]" in alice_line
+    assert "[ghost]" not in bob_line
+
+
+def test_render_table_ghost_indicator_tty():
+    rows = [
+        {"username": "alice", "2025": 0},
+        {"username": "bob", "2025": 50},
+    ]
+    with patch("ghsnitch.ui.IS_TTY", True):
+        output = render_table(rows, ["2025"], ghost_usernames={"alice"})
+    assert "👻" in output
+
+
+def test_render_table_no_ghost_when_not_provided():
+    rows = [{"username": "alice", "2025": 0}]
+    with patch("ghsnitch.ui.IS_TTY", False):
+        output = render_table(rows, ["2025"])
+    assert "[ghost]" not in output
+    assert "👻" not in output
+
+
+def test_render_table_non_ghost_unaffected():
+    rows = [
+        {"username": "alice", "2025": 0},
+        {"username": "bob", "2025": 100},
+    ]
+    with patch("ghsnitch.ui.IS_TTY", False):
+        output = render_table(rows, ["2025"], ghost_usernames={"alice"})
+    # bob has contributions and must not get the ghost mark
+    bob_line = next(ln for ln in output.splitlines() if "bob" in ln)
+    assert "[ghost]" not in bob_line

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -856,3 +856,99 @@ def test_render_table_non_ghost_unaffected():
     # bob has contributions and must not get the ghost mark
     bob_line = next(ln for ln in output.splitlines() if "bob" in ln)
     assert "[ghost]" not in bob_line
+
+
+# ---------------------------------------------------------------------------
+# --redact mode
+# ---------------------------------------------------------------------------
+
+
+def test_make_operative_cell_redact_non_tty():
+    with patch("ghsnitch.ui.IS_TTY", False):
+        result = make_operative_cell("alice", display_name="Operative Alpha")
+    assert result == "Operative Alpha"
+    assert "alice" not in result
+    assert "\033]8;;" not in result
+
+
+def test_make_operative_cell_redact_tty_no_hyperlink():
+    with patch("ghsnitch.ui.IS_TTY", True):
+        result = make_operative_cell("alice", display_name="Operative Alpha")
+    assert "Operative Alpha" in result
+    assert "\033]8;;" not in result
+
+
+def test_make_operative_cell_redact_with_ghost():
+    with patch("ghsnitch.ui.IS_TTY", False):
+        result = make_operative_cell(
+            "alice", is_ghost=True, display_name="Operative Alpha"
+        )
+    assert "Operative Alpha" in result
+    assert "[ghost]" in result
+    assert "alice" not in result
+
+
+def test_render_table_redact_uses_codename():
+    rows = [
+        {"username": "alice", "2025": 100},
+        {"username": "bob", "2025": 50},
+    ]
+    with patch("ghsnitch.ui.IS_TTY", False):
+        output = render_table(
+            rows,
+            ["2025"],
+            redact_map={"alice": "Operative Alpha", "bob": "Operative Bravo"},
+        )
+    assert "Operative Alpha" in output
+    assert "Operative Bravo" in output
+    assert "alice" not in output
+    assert "bob" not in output
+
+
+def test_render_table_redact_no_hyperlinks_tty():
+    rows = [{"username": "alice", "2025": 100}]
+    with patch("ghsnitch.ui.IS_TTY", True):
+        output = render_table(rows, ["2025"], redact_map={"alice": "Operative Alpha"})
+    assert "\033]8;;" not in output
+
+
+def test_render_table_no_redact_when_map_none():
+    rows = [{"username": "alice", "2025": 100}]
+    with patch("ghsnitch.ui.IS_TTY", False):
+        output = render_table(rows, ["2025"], redact_map=None)
+    assert "alice" in output
+
+
+def test_render_json_redact_operative_field():
+    import json as _json
+
+    rows = [{"username": "alice", "2025": 100}]
+    output = render_json(rows, ["2025"], redact_map={"alice": "Operative Alpha"})
+    data = _json.loads(output)
+    assert data[0]["operative"] == "Operative Alpha"
+    assert "alice" not in output
+
+
+def test_render_csv_redact_operative_column():
+    rows = [{"username": "alice", "2025": 100}]
+    output = render_csv(rows, ["2025"], redact_map={"alice": "Operative Alpha"})
+    assert "Operative Alpha" in output
+    assert "alice" not in output
+
+
+def test_render_markdown_redact_operative_column():
+    rows = [{"username": "alice", "2025": 100}]
+    output = render_markdown(rows, ["2025"], redact_map={"alice": "Operative Alpha"})
+    assert "Operative Alpha" in output
+    assert "alice" not in output
+
+
+def test_render_table_redact_unmapped_shows_username():
+    rows = [
+        {"username": "alice", "2025": 100},
+        {"username": "unknown", "2025": 50},
+    ]
+    with patch("ghsnitch.ui.IS_TTY", False):
+        output = render_table(rows, ["2025"], redact_map={"alice": "Operative Alpha"})
+    assert "Operative Alpha" in output
+    assert "unknown" in output

--- a/uv.lock
+++ b/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "ghsnitch"
-version = "0.21.0"
+version = "0.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "asciichartpy" },


### PR DESCRIPTION
## Summary

- Adds `--redact` flag that replaces operative usernames with deterministic NATO phonetic codenames (Operative Alpha, Bravo, Charlie, …) so reports can be shared publicly without exposing GitHub handles
- Codenames are assigned in alphabetical order of the real username — stable and deterministic across runs
- Suppresses OSC 8 terminal hyperlinks in redact mode (no clickable links that could reveal a handle)
- Works across all five output formats: `table`, `json`, `csv`, `markdown`, `graph`
- Ghost indicators (`👻` / `[ghost]`) compose correctly with redacted names
- `not_found` error messages also use the codename so no real handles leak to stderr

Closes #21

## Changes

| File | What changed |
|---|---|
| `src/ghsnitch/cli.py` | `--redact` option, `_NATO_ALPHABET` constant, `redact_map` build logic, passed to all render calls and error messages |
| `src/ghsnitch/ui.py` | `make_operative_cell` extended with `display_name` param; `render_table` skips OSC 8 for count cells in redact mode; `redact_map` param added to all render functions |
| `tests/test_ui.py` | 10 new unit tests covering codename cells, ghost+redact composition, hyperlink suppression, and all non-table formats |
| `tests/test_cli.py` | 6 new integration tests covering table/json/csv/markdown formats and codename determinism |
| `README.md` | `--redact` added to options table |
| `docs/manual/options.md` | `--redact` added to full options reference |
| `docs/manual/usage.md` | New "Redacting Operative Identities" section with examples and codename mapping table |

## Test plan

- [x] `make test` — 258 tests pass
- [x] `make lint` — ruff + black clean
- [ ] Smoke test: `gh-snitch --users alice,bob --redact` — verify codenames appear, no real handles in output
- [ ] Smoke test with `--format json` — confirm `operative` field contains codename
- [ ] Verify `--redact` composes with `--totals`, `--percent`, and `--delta`

https://claude.ai/code/session_013Z95UmTrCjHztPhB8zrDXP

---
_Generated by [Claude Code](https://claude.ai/code/session_013Z95UmTrCjHztPhB8zrDXP)_