### PR TITLE
fix: use index-based GraphQL aliases to prevent fieldConflict collisions

### DIFF
--- a/src/ghsnitch/api.py
+++ b/src/ghsnitch/api.py
@@ -122,8 +122,8 @@ def get_period_range(period: str) -> tuple[str, str, str]:
 def build_contributions_query(users, from_iso, to_iso):
     """Build a GraphQL query with aliases for each user."""
     aliases = []
-    for username in users:
-        alias = f"user_{username.replace('-', '_').replace('.', '_')}"
+    for i, username in enumerate(users):
+        alias = f"user_{i}"
         aliases.append(f"""
   {alias}: user(login: "{username}") {{
     login
@@ -264,8 +264,8 @@ def fetch_contributions(
         for completed, future in enumerate(as_completed(futures), start=1):
             label, response_data = future.result()
 
-            for username in users:
-                alias = f"user_{username.replace('-', '_').replace('.', '_')}"
+            for i, username in enumerate(users):
+                alias = f"user_{i}"
                 user_data = response_data.get(alias)
                 if user_data is None:
                     logger.warning(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -207,7 +207,7 @@ def test_fetch_contributions_with_period(requests_mock):
         "https://api.github.com/graphql",
         json={
             "data": {
-                "user_alice": {
+                "user_0": {
                     "login": "alice",
                     "contributionsCollection": {
                         "contributionCalendar": {"totalContributions": 7}
@@ -257,8 +257,8 @@ def test_build_contributions_query_contains_aliases():
     query = build_contributions_query(
         ["alice", "bob"], "2025-01-01T00:00:00+00:00", "2025-12-31T23:59:59+00:00"
     )
-    assert "user_alice" in query
-    assert "user_bob" in query
+    assert "user_0" in query
+    assert "user_1" in query
     assert "contributionCalendar" in query
     assert "totalContributions" in query
 
@@ -267,7 +267,19 @@ def test_build_contributions_query_handles_hyphen_in_username():
     query = build_contributions_query(
         ["my-user"], "2025-01-01T00:00:00+00:00", "2025-12-31T23:59:59+00:00"
     )
-    assert "user_my_user" in query
+    assert "user_0" in query
+    assert 'login: "my-user"' in query
+
+
+def test_build_contributions_query_no_alias_collision_for_similar_usernames():
+    """agent-007 and agent_007 must not produce the same GraphQL alias."""
+    query = build_contributions_query(
+        ["agent-007", "agent_007"],
+        "2025-01-01T00:00:00+00:00",
+        "2025-12-31T23:59:59+00:00",
+    )
+    assert 'user_0: user(login: "agent-007")' in query
+    assert 'user_1: user(login: "agent_007")' in query
 
 
 def test_fetch_contributions_parses_response(requests_mock):
@@ -277,7 +289,7 @@ def test_fetch_contributions_parses_response(requests_mock):
     def graphql_handler(request, context):
         return {
             "data": {
-                "user_alice": {
+                "user_0": {
                     "login": "alice",
                     "contributionsCollection": {
                         "contributionCalendar": {"totalContributions": 150}
@@ -301,7 +313,7 @@ def test_fetch_contributions_null_user_returns_zero(requests_mock):
 
     requests_mock.post(
         "https://api.github.com/graphql",
-        json={"data": {"user_ghost": None}},
+        json={"data": {"user_0": None}},
     )
 
     with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
@@ -318,7 +330,7 @@ def test_fetch_contributions_uses_enterprise_url(requests_mock):
         "https://github.example.com/api/graphql",
         json={
             "data": {
-                "user_alice": {
+                "user_0": {
                     "login": "alice",
                     "contributionsCollection": {
                         "contributionCalendar": {"totalContributions": 99}
@@ -342,7 +354,7 @@ def test_fetch_contributions_calls_on_progress(requests_mock):
         "https://api.github.com/graphql",
         json={
             "data": {
-                "user_alice": {
+                "user_0": {
                     "login": "alice",
                     "contributionsCollection": {
                         "contributionCalendar": {"totalContributions": 1}
@@ -369,11 +381,11 @@ def test_fetch_contributions_not_found_user_via_graphql_error(requests_mock):
     requests_mock.post(
         "https://api.github.com/graphql",
         json={
-            "data": {"user_ghost": None},
+            "data": {"user_0": None},
             "errors": [
                 {
                     "type": "NOT_FOUND",
-                    "path": ["user_ghost"],
+                    "path": ["user_0"],
                     "message": "Could not resolve to a User with the login of 'ghost'.",
                 }
             ],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,6 +18,31 @@ from ghsnitch.api import (
 )
 
 
+def _graphql_response(*users, errors=None):
+    """Build a mock GraphQL response dict matching the current alias scheme.
+
+    Pass (login, total_contributions) pairs; use None for count to simulate
+    a null/not-found user:
+        _graphql_response(("alice", 50), ("bob", 30))
+        _graphql_response(("ghost", None), errors=[{...}])
+    """
+    data = {}
+    for i, (login, count) in enumerate(users):
+        if count is None:
+            data[f"user_{i}"] = None
+        else:
+            data[f"user_{i}"] = {
+                "login": login,
+                "contributionsCollection": {
+                    "contributionCalendar": {"totalContributions": count}
+                },
+            }
+    response = {"data": data}
+    if errors is not None:
+        response["errors"] = errors
+    return response
+
+
 def test_graphql_url_for_github_com():
     assert graphql_url_for("https://github.com") == "https://api.github.com/graphql"
 
@@ -205,16 +230,7 @@ def test_get_custom_range_since_after_until():
 def test_fetch_contributions_with_period(requests_mock):
     requests_mock.post(
         "https://api.github.com/graphql",
-        json={
-            "data": {
-                "user_0": {
-                    "login": "alice",
-                    "contributionsCollection": {
-                        "contributionCalendar": {"totalContributions": 7}
-                    },
-                }
-            }
-        },
+        json=_graphql_response(("alice", 7)),
     )
 
     with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
@@ -287,16 +303,7 @@ def test_fetch_contributions_parses_response(requests_mock):
     prior_year = str(date.today().year - 1)
 
     def graphql_handler(request, context):
-        return {
-            "data": {
-                "user_0": {
-                    "login": "alice",
-                    "contributionsCollection": {
-                        "contributionCalendar": {"totalContributions": 150}
-                    },
-                }
-            }
-        }
+        return _graphql_response(("alice", 150))
 
     requests_mock.post("https://api.github.com/graphql", json=graphql_handler)
 
@@ -313,7 +320,7 @@ def test_fetch_contributions_null_user_returns_zero(requests_mock):
 
     requests_mock.post(
         "https://api.github.com/graphql",
-        json={"data": {"user_0": None}},
+        json=_graphql_response(("ghost", None)),
     )
 
     with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
@@ -328,16 +335,7 @@ def test_fetch_contributions_uses_enterprise_url(requests_mock):
 
     requests_mock.post(
         "https://github.example.com/api/graphql",
-        json={
-            "data": {
-                "user_0": {
-                    "login": "alice",
-                    "contributionsCollection": {
-                        "contributionCalendar": {"totalContributions": 99}
-                    },
-                }
-            }
-        },
+        json=_graphql_response(("alice", 99)),
     )
 
     with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):
@@ -352,16 +350,7 @@ def test_fetch_contributions_uses_enterprise_url(requests_mock):
 def test_fetch_contributions_calls_on_progress(requests_mock):
     requests_mock.post(
         "https://api.github.com/graphql",
-        json={
-            "data": {
-                "user_0": {
-                    "login": "alice",
-                    "contributionsCollection": {
-                        "contributionCalendar": {"totalContributions": 1}
-                    },
-                }
-            }
-        },
+        json=_graphql_response(("alice", 1)),
     )
 
     calls = []
@@ -380,16 +369,16 @@ def test_fetch_contributions_not_found_user_via_graphql_error(requests_mock):
 
     requests_mock.post(
         "https://api.github.com/graphql",
-        json={
-            "data": {"user_0": None},
-            "errors": [
+        json=_graphql_response(
+            ("ghost", None),
+            errors=[
                 {
                     "type": "NOT_FOUND",
                     "path": ["user_0"],
                     "message": "Could not resolve to a User with the login of 'ghost'.",
                 }
             ],
-        },
+        ),
     )
 
     with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", "fake-token"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,7 +75,7 @@ def test_successful_run_renders_table(runner, tmp_path, requests_mock):
         "https://api.github.com/graphql",
         json={
             "data": {
-                "user_alice": {
+                "user_0": {
                     "login": "alice",
                     "contributionsCollection": {
                         "contributionCalendar": {"totalContributions": 42}
@@ -108,7 +108,7 @@ def test_no_update_check_skips_update(runner, tmp_path, requests_mock):
         "https://api.github.com/graphql",
         json={
             "data": {
-                "user_alice": {
+                "user_0": {
                     "login": "alice",
                     "contributionsCollection": {
                         "contributionCalendar": {"totalContributions": 10}
@@ -138,7 +138,7 @@ def test_github_url_cli_override(runner, tmp_path, requests_mock):
         "https://github.example.com/api/graphql",
         json={
             "data": {
-                "user_alice": {
+                "user_0": {
                     "login": "alice",
                     "contributionsCollection": {
                         "contributionCalendar": {"totalContributions": 5}
@@ -207,11 +207,11 @@ def test_not_found_operative_shows_warning_and_exits_nonzero(
     requests_mock.post(
         "https://api.github.com/graphql",
         json={
-            "data": {"user_ghost": None},
+            "data": {"user_0": None},
             "errors": [
                 {
                     "type": "NOT_FOUND",
-                    "path": ["user_ghost"],
+                    "path": ["user_0"],
                     "message": "Could not resolve to a User with the login of 'ghost'.",
                 }
             ],
@@ -240,13 +240,13 @@ def test_min_contributions_suppresses_below_threshold(runner, tmp_path, requests
         "https://api.github.com/graphql",
         json={
             "data": {
-                "user_alice": {
+                "user_0": {
                     "login": "alice",
                     "contributionsCollection": {
                         "contributionCalendar": {"totalContributions": 50}
                     },
                 },
-                "user_bob": {
+                "user_1": {
                     "login": "bob",
                     "contributionsCollection": {
                         "contributionCalendar": {"totalContributions": 3}
@@ -285,13 +285,13 @@ def test_min_contributions_zero_shows_all(runner, tmp_path, requests_mock):
         "https://api.github.com/graphql",
         json={
             "data": {
-                "user_alice": {
+                "user_0": {
                     "login": "alice",
                     "contributionsCollection": {
                         "contributionCalendar": {"totalContributions": 50}
                     },
                 },
-                "user_bob": {
+                "user_1": {
                     "login": "bob",
                     "contributionsCollection": {
                         "contributionCalendar": {"totalContributions": 0}
@@ -333,13 +333,13 @@ def test_min_contributions_from_config(runner, tmp_path, requests_mock):
         "https://api.github.com/graphql",
         json={
             "data": {
-                "user_alice": {
+                "user_0": {
                     "login": "alice",
                     "contributionsCollection": {
                         "contributionCalendar": {"totalContributions": 50}
                     },
                 },
-                "user_bob": {
+                "user_1": {
                     "login": "bob",
                     "contributionsCollection": {
                         "contributionCalendar": {"totalContributions": 5}
@@ -370,7 +370,7 @@ def test_users_cli_override(runner, tmp_path, requests_mock):
         "https://api.github.com/graphql",
         json={
             "data": {
-                "user_bob": {
+                "user_0": {
                     "login": "bob",
                     "contributionsCollection": {
                         "contributionCalendar": {"totalContributions": 7}
@@ -392,7 +392,7 @@ def test_users_cli_override(runner, tmp_path, requests_mock):
 
 _GRAPHQL_RESPONSE = {
     "data": {
-        "user_alice": {
+        "user_0": {
             "login": "alice",
             "contributionsCollection": {
                 "contributionCalendar": {"totalContributions": 50}
@@ -1025,7 +1025,7 @@ def test_team_selects_users_from_config(runner, tmp_path, requests_mock):
         "https://api.github.com/graphql",
         json={
             "data": {
-                "user_alice": {
+                "user_0": {
                     "login": "alice",
                     "contributionsCollection": {
                         "contributionCalendar": {"totalContributions": 42}
@@ -1083,7 +1083,7 @@ def test_users_overrides_team(runner, tmp_path, requests_mock):
         "https://api.github.com/graphql",
         json={
             "data": {
-                "user_bob": {
+                "user_0": {
                     "login": "bob",
                     "contributionsCollection": {
                         "contributionCalendar": {"totalContributions": 7}
@@ -1121,18 +1121,21 @@ def test_team_snapshots_are_partitioned(runner, tmp_path, requests_mock):
         "[surveillance]\nyears = 0\n"
     )
 
-    # Mock response for alice (alpha) and bob (beta)
+    # Mock response covers all three invocations:
+    # - alpha (["alice"]): user_0 → alice
+    # - beta  (["bob"]):   user_0 → bob
+    # - ad-hoc (["alice","bob"]): user_0 → alice, user_1 → bob
     requests_mock.post(
         "https://api.github.com/graphql",
         json={
             "data": {
-                "user_alice": {
+                "user_0": {
                     "login": "alice",
                     "contributionsCollection": {
                         "contributionCalendar": {"totalContributions": 10}
                     },
                 },
-                "user_bob": {
+                "user_1": {
                     "login": "bob",
                     "contributionsCollection": {
                         "contributionCalendar": {"totalContributions": 20}
@@ -1366,7 +1369,7 @@ def test_rank_delta_column_visible_by_default(runner, tmp_path, requests_mock):
         "https://api.github.com/graphql",
         json={
             "data": {
-                "user_alice": {
+                "user_0": {
                     "login": "alice",
                     "contributionsCollection": {
                         "contributionCalendar": {"totalContributions": 10}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,31 @@ def _context_id(users):
     return f"u-{hashlib.sha256(key.encode()).hexdigest()[:12]}"
 
 
+def _graphql_response(*users, errors=None):
+    """Build a mock GraphQL response dict matching the current alias scheme.
+
+    Pass (login, total_contributions) pairs; use None for count to simulate
+    a null/not-found user:
+        _graphql_response(("alice", 50), ("bob", 30))
+        _graphql_response(("ghost", None), errors=[{...}])
+    """
+    data = {}
+    for i, (login, count) in enumerate(users):
+        if count is None:
+            data[f"user_{i}"] = None
+        else:
+            data[f"user_{i}"] = {
+                "login": login,
+                "contributionsCollection": {
+                    "contributionCalendar": {"totalContributions": count}
+                },
+            }
+    response = {"data": data}
+    if errors is not None:
+        response["errors"] = errors
+    return response
+
+
 @pytest.fixture
 def runner():
     return CliRunner()
@@ -73,16 +98,7 @@ def test_successful_run_renders_table(runner, tmp_path, requests_mock):
 
     requests_mock.post(
         "https://api.github.com/graphql",
-        json={
-            "data": {
-                "user_0": {
-                    "login": "alice",
-                    "contributionsCollection": {
-                        "contributionCalendar": {"totalContributions": 42}
-                    },
-                }
-            }
-        },
+        json=_graphql_response(("alice", 42)),
     )
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
@@ -106,16 +122,7 @@ def test_no_update_check_skips_update(runner, tmp_path, requests_mock):
 
     requests_mock.post(
         "https://api.github.com/graphql",
-        json={
-            "data": {
-                "user_0": {
-                    "login": "alice",
-                    "contributionsCollection": {
-                        "contributionCalendar": {"totalContributions": 10}
-                    },
-                }
-            }
-        },
+        json=_graphql_response(("alice", 10)),
     )
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
@@ -136,16 +143,7 @@ def test_github_url_cli_override(runner, tmp_path, requests_mock):
 
     requests_mock.post(
         "https://github.example.com/api/graphql",
-        json={
-            "data": {
-                "user_0": {
-                    "login": "alice",
-                    "contributionsCollection": {
-                        "contributionCalendar": {"totalContributions": 5}
-                    },
-                }
-            }
-        },
+        json=_graphql_response(("alice", 5)),
     )
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
@@ -206,16 +204,16 @@ def test_not_found_operative_shows_warning_and_exits_nonzero(
 
     requests_mock.post(
         "https://api.github.com/graphql",
-        json={
-            "data": {"user_0": None},
-            "errors": [
+        json=_graphql_response(
+            ("ghost", None),
+            errors=[
                 {
                     "type": "NOT_FOUND",
                     "path": ["user_0"],
                     "message": "Could not resolve to a User with the login of 'ghost'.",
                 }
             ],
-        },
+        ),
     )
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
@@ -238,22 +236,7 @@ def test_min_contributions_suppresses_below_threshold(runner, tmp_path, requests
 
     requests_mock.post(
         "https://api.github.com/graphql",
-        json={
-            "data": {
-                "user_0": {
-                    "login": "alice",
-                    "contributionsCollection": {
-                        "contributionCalendar": {"totalContributions": 50}
-                    },
-                },
-                "user_1": {
-                    "login": "bob",
-                    "contributionsCollection": {
-                        "contributionCalendar": {"totalContributions": 3}
-                    },
-                },
-            }
-        },
+        json=_graphql_response(("alice", 50), ("bob", 3)),
     )
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
@@ -283,22 +266,7 @@ def test_min_contributions_zero_shows_all(runner, tmp_path, requests_mock):
 
     requests_mock.post(
         "https://api.github.com/graphql",
-        json={
-            "data": {
-                "user_0": {
-                    "login": "alice",
-                    "contributionsCollection": {
-                        "contributionCalendar": {"totalContributions": 50}
-                    },
-                },
-                "user_1": {
-                    "login": "bob",
-                    "contributionsCollection": {
-                        "contributionCalendar": {"totalContributions": 0}
-                    },
-                },
-            }
-        },
+        json=_graphql_response(("alice", 50), ("bob", 0)),
     )
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
@@ -331,22 +299,7 @@ def test_min_contributions_from_config(runner, tmp_path, requests_mock):
 
     requests_mock.post(
         "https://api.github.com/graphql",
-        json={
-            "data": {
-                "user_0": {
-                    "login": "alice",
-                    "contributionsCollection": {
-                        "contributionCalendar": {"totalContributions": 50}
-                    },
-                },
-                "user_1": {
-                    "login": "bob",
-                    "contributionsCollection": {
-                        "contributionCalendar": {"totalContributions": 5}
-                    },
-                },
-            }
-        },
+        json=_graphql_response(("alice", 50), ("bob", 5)),
     )
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
@@ -368,16 +321,7 @@ def test_users_cli_override(runner, tmp_path, requests_mock):
 
     requests_mock.post(
         "https://api.github.com/graphql",
-        json={
-            "data": {
-                "user_0": {
-                    "login": "bob",
-                    "contributionsCollection": {
-                        "contributionCalendar": {"totalContributions": 7}
-                    },
-                }
-            }
-        },
+        json=_graphql_response(("bob", 7)),
     )
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):
@@ -390,16 +334,7 @@ def test_users_cli_override(runner, tmp_path, requests_mock):
     assert result.exit_code == 0
 
 
-_GRAPHQL_RESPONSE = {
-    "data": {
-        "user_0": {
-            "login": "alice",
-            "contributionsCollection": {
-                "contributionCalendar": {"totalContributions": 50}
-            },
-        }
-    }
-}
+_GRAPHQL_RESPONSE = _graphql_response(("alice", 50))
 
 
 def test_reset_snapshot_clears_and_exits(runner, tmp_path):
@@ -1023,16 +958,7 @@ def test_team_selects_users_from_config(runner, tmp_path, requests_mock):
     )
     requests_mock.post(
         "https://api.github.com/graphql",
-        json={
-            "data": {
-                "user_0": {
-                    "login": "alice",
-                    "contributionsCollection": {
-                        "contributionCalendar": {"totalContributions": 42}
-                    },
-                }
-            }
-        },
+        json=_graphql_response(("alice", 42)),
     )
     result = _run(runner, config_file, tmp_path, ["--team", "platform"])
     assert result.exit_code == 0
@@ -1081,16 +1007,7 @@ def test_users_overrides_team(runner, tmp_path, requests_mock):
     )
     requests_mock.post(
         "https://api.github.com/graphql",
-        json={
-            "data": {
-                "user_0": {
-                    "login": "bob",
-                    "contributionsCollection": {
-                        "contributionCalendar": {"totalContributions": 7}
-                    },
-                }
-            }
-        },
+        json=_graphql_response(("bob", 7)),
     )
     result = _run(
         runner, config_file, tmp_path, ["--users", "bob", "--team", "platform"]
@@ -1127,22 +1044,7 @@ def test_team_snapshots_are_partitioned(runner, tmp_path, requests_mock):
     # - ad-hoc (["alice","bob"]): user_0 → alice, user_1 → bob
     requests_mock.post(
         "https://api.github.com/graphql",
-        json={
-            "data": {
-                "user_0": {
-                    "login": "alice",
-                    "contributionsCollection": {
-                        "contributionCalendar": {"totalContributions": 10}
-                    },
-                },
-                "user_1": {
-                    "login": "bob",
-                    "contributionsCollection": {
-                        "contributionCalendar": {"totalContributions": 20}
-                    },
-                },
-            }
-        },
+        json=_graphql_response(("alice", 10), ("bob", 20)),
     )
 
     # We patch CACHE_DIR so we can see the real filenames
@@ -1364,19 +1266,9 @@ def test_rank_delta_column_visible_by_default(runner, tmp_path, requests_mock):
     config_file = tmp_path / "config.toml"
     config_file.write_text('[operatives]\nusers = ["alice"]\n')
 
-    # Mock response
     requests_mock.post(
         "https://api.github.com/graphql",
-        json={
-            "data": {
-                "user_0": {
-                    "login": "alice",
-                    "contributionsCollection": {
-                        "contributionCalendar": {"totalContributions": 10}
-                    },
-                }
-            }
-        },
+        json=_graphql_response(("alice", 10)),
     )
 
     with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", "fake-token"):

--- a/uv.lock
+++ b/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "ghsnitch"
-version = "0.22.0"
+version = "0.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "asciichartpy" },


### PR DESCRIPTION
Usernames that differ only by hyphen vs underscore (e.g. agent-007 /
agent_007) previously collapsed to the same sanitised alias, causing
GitHub's GraphQL API to reject the query with a fieldConflict error.

Replace the username-derived alias scheme with sequential integer aliases
(user_0, user_1, …) which are guaranteed unique regardless of username
content. Update the response parser and all test fixtures accordingly.
Add a regression test asserting the two similar usernames produce distinct
aliases.

Closes #83

https://claude.ai/code/session_019TU5tGZQULg7dpzsVoSwuo