### PR TITLE
feat: add --format stack stacked bar chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ make build
 | `--min-contributions` | Hide operatives below this contribution count |
 | `--totals` | Add a Total column per operative and a Total footer row |
 | `--percent` | Annotate each cell with the operative's `(N%)` share of that year's total |
-| `--format` | Output format: `table` (default), `json`, `csv`, `markdown`, `graph` |
+| `--format` | Output format: `table` (default), `json`, `csv`, `markdown`, `graph`, `stack` |
 | `--no-rank-delta` | Hide the `±` rank-change column (shown by default) |
 | `--redact` | Replace operative usernames with NATO phonetic codenames (Operative Alpha, Bravo, …) for shareable reports |
 | `--delta` | Show change since last snapshot instead of current-year count |

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -15,7 +15,7 @@
 | `--min-contributions INTEGER` | `0` (show all) | Hide operatives with fewer than N contributions in the current year |
 | `--totals` | off | Add a `Total` column (per-operative sum across all years) and a `Total` footer row (per-year sum across all operatives) |
 | `--percent` | off | Annotate each contribution cell with the operative's `(N%)` share of that year's total; percentages are colour-graded in TTY mode |
-| `--format TEXT` | `table` (from config) | Output format: `table`, `json`, `csv`, `markdown`, or `graph`. Non-table formats write clean data to stdout and send status messages to stderr. |
+| `--format TEXT` | `table` (from config) | Output format: `table`, `json`, `csv`, `markdown`, `graph`, or `stack`. Non-table formats write clean data to stdout and send status messages to stderr. |
 | `--no-rank-delta` | off | Hide the `±` rank-change column (rank delta is shown by default) |
 | `--redact` | off | Replace operative usernames with NATO phonetic codenames (Operative Alpha, Bravo, …); suppresses hyperlinks. Codenames are assigned in alphabetical order of the real username and are deterministic across runs. Works with all output formats. |
 | `--delta` | off | Replace the current-year column with `Δ Today` showing the change since the last saved snapshot; green/red-coded |
@@ -64,7 +64,7 @@ years = 3
 # github_url = "https://github.example.com"  # omit for github.com
 
 [display]
-# format = "table"      # table (default), json, csv, markdown, or graph
+# format = "table"      # table (default), json, csv, markdown, graph, or stack
 # min_contributions = 10  # hide operatives below this threshold
 # totals = false           # show Total column and footer row
 # percent = false          # annotate cells with (N%) share of year total

--- a/docs/manual/usage.md
+++ b/docs/manual/usage.md
@@ -188,7 +188,7 @@ If you have more than 26 operatives the sequence continues as Operative Alpha-2,
 
 In redact mode:
 - OSC 8 terminal hyperlinks are suppressed — no clickable links that could reveal the real handle
-- The codename replaces the username in all output formats (`table`, `json`, `csv`, `markdown`, `graph`)
+- The codename replaces the username in all output formats (`table`, `json`, `csv`, `markdown`, `graph`, `stack`)
 - Ghost indicators (`👻` / `[ghost]`) are still shown alongside the codename
 - Error messages for not-found operatives also use the codename
 
@@ -362,6 +362,27 @@ gh-snitch --team platform --delta --format graph
 ```
 
 **Note:** The `--totals` and `--percent` flags are ignored in graph mode.
+
+## Stacked Bar Chart
+
+Render a vertical stacked bar chart showing each operative's share of the team's total contributions per year:
+
+```bash
+gh-snitch --users alice,bob,charlie --years 3 --format stack
+```
+
+- **X-axis:** Years (chronological left→right)
+- **Y-axis:** Contribution count (scaled to terminal height)
+- **Stacking:** Each year's bar is divided into colour-coded segments, one per operative, proportional to their share of that year's total
+- **Legend:** Displayed below the chart, left→right matching bottom→top stack order
+
+The stacked view makes it easy to see team trajectory (bar height) and each person's relative contribution (segment size) at a glance. Combine with `--redact` to share publicly:
+
+```bash
+gh-snitch --team platform --years 3 --format stack --redact
+```
+
+**Note:** `--totals` and `--percent` are not applicable in stack format and are ignored.
 
 ## One-Shot Command
 

--- a/src/ghsnitch/cli.py
+++ b/src/ghsnitch/cli.py
@@ -32,10 +32,17 @@ from .snapshot import (
     load_snapshot,
     save_snapshot,
 )
-from .ui import render_csv, render_graph, render_json, render_markdown, render_table
+from .ui import (
+    render_csv,
+    render_graph,
+    render_json,
+    render_markdown,
+    render_stack,
+    render_table,
+)
 from .updater import check_for_update
 
-VALID_FORMATS = ("table", "json", "csv", "markdown", "graph")
+VALID_FORMATS = ("table", "json", "csv", "markdown", "graph", "stack")
 
 _NATO_ALPHABET = [
     "Alpha",
@@ -665,6 +672,12 @@ def gh_snitch(  # noqa: PLR0913
         click.echo(
             render_graph(rows, year_labels, show_totals=show_totals, redact_map=_redact)
         )
+    elif active_format == "stack":
+        if cfg.get("percent"):
+            click.echo("⚠️  --percent is ignored in stack format.", err=True)
+        if show_totals:
+            click.echo("⚠️  --totals is ignored in stack format.", err=True)
+        click.echo(render_stack(rows, year_labels, redact_map=_redact))
     else:
         table = render_table(
             rows,

--- a/src/ghsnitch/ui.py
+++ b/src/ghsnitch/ui.py
@@ -666,18 +666,30 @@ def render_graph(rows, year_labels, show_totals=False, redact_map=None):
 # ---------------------------------------------------------------------------
 
 _ANSI_COLORS = [
-    "\033[96m",  # bright cyan
-    "\033[95m",  # bright magenta
-    "\033[92m",  # bright green
-    "\033[93m",  # bright yellow
-    "\033[94m",  # bright blue
-    "\033[91m",  # bright red
-    "\033[36m",  # cyan
-    "\033[35m",  # magenta
-    "\033[32m",  # green
-    "\033[33m",  # yellow
-    "\033[34m",  # blue
-    "\033[31m",  # red
+    "\033[38;5;196m",  # red
+    "\033[38;5;46m",  # green
+    "\033[38;5;21m",  # blue
+    "\033[38;5;226m",  # yellow
+    "\033[38;5;201m",  # magenta
+    "\033[38;5;51m",  # cyan
+    "\033[38;5;208m",  # orange
+    "\033[38;5;129m",  # violet
+    "\033[38;5;118m",  # lime
+    "\033[38;5;27m",  # royal blue
+    "\033[38;5;214m",  # amber
+    "\033[38;5;87m",  # aqua
+    "\033[38;5;160m",  # crimson
+    "\033[38;5;82m",  # chartreuse
+    "\033[38;5;57m",  # indigo
+    "\033[38;5;220m",  # gold
+    "\033[38;5;48m",  # spring green
+    "\033[38;5;165m",  # orchid
+    "\033[38;5;203m",  # coral
+    "\033[38;5;75m",  # sky blue
+    "\033[38;5;154m",  # yellow-green
+    "\033[38;5;93m",  # blue-violet
+    "\033[38;5;190m",  # lime-yellow
+    "\033[38;5;39m",  # cornflower
 ]
 _ANSI_RESET = "\033[0m"
 _BLOCK = "█"

--- a/src/ghsnitch/ui.py
+++ b/src/ghsnitch/ui.py
@@ -666,30 +666,18 @@ def render_graph(rows, year_labels, show_totals=False, redact_map=None):
 # ---------------------------------------------------------------------------
 
 _ANSI_COLORS = [
-    "\033[38;5;196m",  # red
-    "\033[38;5;46m",  # green
-    "\033[38;5;21m",  # blue
-    "\033[38;5;226m",  # yellow
-    "\033[38;5;201m",  # magenta
-    "\033[38;5;51m",  # cyan
-    "\033[38;5;208m",  # orange
-    "\033[38;5;129m",  # violet
-    "\033[38;5;118m",  # lime
-    "\033[38;5;27m",  # royal blue
-    "\033[38;5;214m",  # amber
-    "\033[38;5;87m",  # aqua
-    "\033[38;5;160m",  # crimson
-    "\033[38;5;82m",  # chartreuse
-    "\033[38;5;57m",  # indigo
-    "\033[38;5;220m",  # gold
-    "\033[38;5;48m",  # spring green
-    "\033[38;5;165m",  # orchid
-    "\033[38;5;203m",  # coral
-    "\033[38;5;75m",  # sky blue
-    "\033[38;5;154m",  # yellow-green
-    "\033[38;5;93m",  # blue-violet
-    "\033[38;5;190m",  # lime-yellow
-    "\033[38;5;39m",  # cornflower
+    "\033[96m",  # bright cyan
+    "\033[95m",  # bright magenta
+    "\033[92m",  # bright green
+    "\033[93m",  # bright yellow
+    "\033[94m",  # bright blue
+    "\033[91m",  # bright red
+    "\033[36m",  # cyan
+    "\033[35m",  # magenta
+    "\033[32m",  # green
+    "\033[33m",  # yellow
+    "\033[34m",  # blue
+    "\033[31m",  # red
 ]
 _ANSI_RESET = "\033[0m"
 _BLOCK = "█"

--- a/src/ghsnitch/ui.py
+++ b/src/ghsnitch/ui.py
@@ -666,30 +666,30 @@ def render_graph(rows, year_labels, show_totals=False, redact_map=None):
 # ---------------------------------------------------------------------------
 
 _ANSI_COLORS = [
-    "\033[38;5;160m",  # red
-    "\033[38;5;34m",  # green
-    "\033[38;5;26m",  # blue
-    "\033[38;5;178m",  # yellow
-    "\033[38;5;127m",  # magenta
-    "\033[38;5;37m",  # teal
-    "\033[38;5;166m",  # orange
-    "\033[38;5;92m",  # violet
-    "\033[38;5;70m",  # lime
-    "\033[38;5;20m",  # royal blue
-    "\033[38;5;172m",  # amber
-    "\033[38;5;73m",  # aqua
-    "\033[38;5;130m",  # burnt orange
-    "\033[38;5;64m",  # olive green
-    "\033[38;5;54m",  # indigo
-    "\033[38;5;136m",  # gold
-    "\033[38;5;42m",  # spring green
-    "\033[38;5;133m",  # orchid
-    "\033[38;5;167m",  # salmon
-    "\033[38;5;68m",  # steel blue
-    "\033[38;5;106m",  # yellow-green
-    "\033[38;5;61m",  # blue-violet
-    "\033[38;5;142m",  # khaki
-    "\033[38;5;74m",  # cornflower
+    "\033[38;5;196m",  # red
+    "\033[38;5;46m",  # green
+    "\033[38;5;21m",  # blue
+    "\033[38;5;226m",  # yellow
+    "\033[38;5;201m",  # magenta
+    "\033[38;5;51m",  # cyan
+    "\033[38;5;208m",  # orange
+    "\033[38;5;129m",  # violet
+    "\033[38;5;118m",  # lime
+    "\033[38;5;27m",  # royal blue
+    "\033[38;5;214m",  # amber
+    "\033[38;5;87m",  # aqua
+    "\033[38;5;160m",  # crimson
+    "\033[38;5;82m",  # chartreuse
+    "\033[38;5;57m",  # indigo
+    "\033[38;5;220m",  # gold
+    "\033[38;5;48m",  # spring green
+    "\033[38;5;165m",  # orchid
+    "\033[38;5;203m",  # coral
+    "\033[38;5;75m",  # sky blue
+    "\033[38;5;154m",  # yellow-green
+    "\033[38;5;93m",  # blue-violet
+    "\033[38;5;190m",  # lime-yellow
+    "\033[38;5;39m",  # cornflower
 ]
 _ANSI_RESET = "\033[0m"
 _BLOCK = "█"

--- a/src/ghsnitch/ui.py
+++ b/src/ghsnitch/ui.py
@@ -666,30 +666,30 @@ def render_graph(rows, year_labels, show_totals=False, redact_map=None):
 # ---------------------------------------------------------------------------
 
 _ANSI_COLORS = [
-    "\033[38;5;196m",  # red
-    "\033[38;5;46m",  # green
-    "\033[38;5;21m",  # blue
-    "\033[38;5;226m",  # yellow
-    "\033[38;5;201m",  # magenta
-    "\033[38;5;51m",  # cyan
-    "\033[38;5;208m",  # orange
-    "\033[38;5;129m",  # violet
-    "\033[38;5;118m",  # lime
-    "\033[38;5;27m",  # royal blue
-    "\033[38;5;214m",  # amber
-    "\033[38;5;87m",  # aqua
-    "\033[38;5;160m",  # crimson
-    "\033[38;5;82m",  # chartreuse
-    "\033[38;5;57m",  # indigo
-    "\033[38;5;220m",  # gold
-    "\033[38;5;48m",  # spring green
-    "\033[38;5;165m",  # orchid
-    "\033[38;5;203m",  # coral
-    "\033[38;5;75m",  # sky blue
-    "\033[38;5;154m",  # yellow-green
-    "\033[38;5;93m",  # blue-violet
-    "\033[38;5;190m",  # lime-yellow
-    "\033[38;5;39m",  # cornflower
+    "\033[38;5;160m",  # red
+    "\033[38;5;34m",  # green
+    "\033[38;5;26m",  # blue
+    "\033[38;5;178m",  # yellow
+    "\033[38;5;127m",  # magenta
+    "\033[38;5;37m",  # teal
+    "\033[38;5;166m",  # orange
+    "\033[38;5;92m",  # violet
+    "\033[38;5;70m",  # lime
+    "\033[38;5;20m",  # royal blue
+    "\033[38;5;172m",  # amber
+    "\033[38;5;73m",  # aqua
+    "\033[38;5;130m",  # burnt orange
+    "\033[38;5;64m",  # olive green
+    "\033[38;5;54m",  # indigo
+    "\033[38;5;136m",  # gold
+    "\033[38;5;42m",  # spring green
+    "\033[38;5;133m",  # orchid
+    "\033[38;5;167m",  # salmon
+    "\033[38;5;68m",  # steel blue
+    "\033[38;5;106m",  # yellow-green
+    "\033[38;5;61m",  # blue-violet
+    "\033[38;5;142m",  # khaki
+    "\033[38;5;74m",  # cornflower
 ]
 _ANSI_RESET = "\033[0m"
 _BLOCK = "█"

--- a/src/ghsnitch/ui.py
+++ b/src/ghsnitch/ui.py
@@ -659,3 +659,135 @@ def render_graph(rows, year_labels, show_totals=False, redact_map=None):
     legend = "          " + ", ".join(legend_items) + "\n"
 
     return f"{title}\n{plot_output}\n\n{legend}"
+
+
+# ---------------------------------------------------------------------------
+# Stacked bar chart
+# ---------------------------------------------------------------------------
+
+_ANSI_COLORS = [
+    "\033[96m",  # bright cyan
+    "\033[95m",  # bright magenta
+    "\033[92m",  # bright green
+    "\033[93m",  # bright yellow
+    "\033[94m",  # bright blue
+    "\033[91m",  # bright red
+    "\033[36m",  # cyan
+    "\033[35m",  # magenta
+    "\033[32m",  # green
+    "\033[33m",  # yellow
+    "\033[34m",  # blue
+    "\033[31m",  # red
+]
+_ANSI_RESET = "\033[0m"
+_BLOCK = "█"
+
+
+def render_stack(rows, year_labels, redact_map=None):
+    """Render a stacked bar chart: one column per year, colour-coded by operative."""
+    if not rows:
+        return "(no operatives configured)"
+
+    x_labels = list(reversed(year_labels))  # chronological left→right
+    current_year_label = year_labels[0]
+
+    # Sort operatives descending by current year (consistent with table order).
+    sorted_rows = sorted(
+        rows, key=lambda r: (-r.get(current_year_label, 0), r["username"])
+    )
+
+    def _display_name(row):
+        u = row["username"]
+        return redact_map.get(u, u) if redact_map else u
+
+    # Per-year totals and per-operative per-year counts.
+    year_totals = {
+        label: sum(r.get(label, 0) for r in sorted_rows) for label in x_labels
+    }
+    overall_max = max(year_totals.values()) if year_totals else 1
+
+    try:
+        term_width, term_height = os.get_terminal_size()
+        chart_height = max(8, min(term_height - 12, 20))
+    except (OSError, AttributeError):
+        term_width = 80
+        chart_height = 12
+
+    # Column width: enough to fit the year label (min 4), capped so all years fit.
+    num_years = len(x_labels)
+    y_axis_width = 7  # "  9999 ┤" style
+    gap = 2
+    col_width = max(
+        4, min(10, (term_width - y_axis_width - gap) // max(num_years, 1) - gap)
+    )
+
+    # Build the chart row by row (top = chart_height, bottom = 0).
+    # For each chart row r (1 = top), the threshold value it represents:
+    #   threshold = overall_max * r / chart_height
+    # A year column cell at row r is filled by operatives whose cumulative
+    # contribution (from the bottom) reaches that threshold.
+
+    # Stack order: smallest operative at bottom, largest at top.
+    # reversed(sorted_rows) → least-current-year first, so it sits at the base.
+    stack_order = list(reversed(sorted_rows))
+
+    lines = []
+    for chart_row in range(chart_height, 0, -1):
+        # Value band this row represents: (prev_threshold, threshold].
+        threshold = overall_max * chart_row / chart_height
+        prev_threshold = overall_max * (chart_row - 1) / chart_height
+        tick_val = round(threshold)
+
+        # Y-axis label on labelled rows, continuation bar elsewhere.
+        if chart_row == chart_height or chart_row % max(1, chart_height // 5) == 0:
+            y_label = f"{tick_val:>{y_axis_width - 2}} ┤"
+        else:
+            y_label = " " * (y_axis_width - 1) + "│"
+
+        cells = []
+        for label in x_labels:
+            total = year_totals[label]
+            if total <= 0 or total < prev_threshold:
+                # Year has no contributions, or total doesn't reach this band.
+                cells.append(" " * col_width)
+                continue
+
+            # Find which operative owns the cumulative band containing prev_threshold.
+            cumulative = 0.0
+            cell_color = ""
+            for op_i, row in enumerate(stack_order):
+                cumulative += row.get(label, 0)
+                if cumulative >= prev_threshold:
+                    if IS_TTY:
+                        cell_color = _ANSI_COLORS[op_i % len(_ANSI_COLORS)]
+                    break
+
+            block = _BLOCK * col_width
+            cells.append(f"{cell_color}{block}{_ANSI_RESET}" if IS_TTY else block)
+
+        lines.append(y_label + (" " * gap).join(cells))
+
+    # X-axis baseline
+    baseline = " " * y_axis_width + ("─" * col_width + "  ") * num_years
+    lines.append(baseline)
+
+    # Year labels centred under each column
+    year_row = " " * y_axis_width
+    for label in x_labels:
+        year_row += label[:col_width].center(col_width) + "  "
+    lines.append(year_row.rstrip())
+
+    # Legend: left→right matches bottom→top stack order.
+    legend_parts = []
+    for i, row in enumerate(stack_order):
+        name = _display_name(row)
+        if IS_TTY:
+            c = _ANSI_COLORS[i % len(_ANSI_COLORS)]
+            legend_parts.append(f"{c}{_BLOCK}{_ANSI_RESET} {name}")
+        else:
+            legend_parts.append(f"{_BLOCK} {name}")
+    legend = "  " + "   ".join(legend_parts)
+
+    title = "\n          🕵️  OPERATIVE SURVEILLANCE DOSSIER — STACKED SURVEILLANCE\n"
+    body = "\n".join(lines)
+    return f"{title}\n{body}\n\n{legend}\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1380,3 +1380,38 @@ def test_redact_markdown_format_uses_codenames(runner, tmp_path, requests_mock):
     assert result.exit_code == 0
     assert "Operative Alpha" in result.output
     assert "alice" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# --format stack
+# ---------------------------------------------------------------------------
+
+
+def test_stack_format_renders_year_labels(runner, tmp_path, requests_mock):
+    requests_mock.post("https://api.github.com/graphql", json=_GRAPHQL_RESPONSE)
+    cfg = _make_config(tmp_path)
+    result = _run(runner, cfg, tmp_path, ["--format", "stack"])
+    assert result.exit_code == 0
+    assert "SURVEILLANCE" in result.output
+
+
+def test_stack_format_renders_operative_in_legend(runner, tmp_path, requests_mock):
+    requests_mock.post(
+        "https://api.github.com/graphql", json=_GRAPHQL_RESPONSE_TWO_USERS
+    )
+    cfg = _make_two_user_config(tmp_path)
+    result = _run(runner, cfg, tmp_path, ["--format", "stack"])
+    assert result.exit_code == 0
+    assert "alice" in result.output
+    assert "bob" in result.output
+
+
+def test_stack_format_redact_shows_codenames(runner, tmp_path, requests_mock):
+    requests_mock.post(
+        "https://api.github.com/graphql", json=_GRAPHQL_RESPONSE_TWO_USERS
+    )
+    cfg = _make_two_user_config(tmp_path)
+    result = _run(runner, cfg, tmp_path, ["--format", "stack", "--redact"])
+    assert result.exit_code == 0
+    assert "Operative Alpha" in result.output
+    assert "alice" not in result.output

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -13,6 +13,7 @@ from ghsnitch.ui import (
     render_graph,
     render_json,
     render_markdown,
+    render_stack,
     render_table,
 )
 
@@ -1021,3 +1022,79 @@ def test_render_graph_redact_uses_codenames_in_legend():
     assert "Operative Bravo" in output
     assert "alice" not in output
     assert "bob" not in output
+
+
+# ---------------------------------------------------------------------------
+# render_stack
+# ---------------------------------------------------------------------------
+
+
+def test_render_stack_empty_rows():
+    assert "no operatives" in render_stack([], ["2025"]).lower()
+
+
+def test_render_stack_contains_year_labels():
+    rows = [{"username": "alice", "2024": 100, "2025": 200}]
+    with patch("ghsnitch.ui.IS_TTY", False):
+        output = render_stack(rows, ["2025", "2024"])
+    assert "2024" in output
+    assert "2025" in output
+
+
+def test_render_stack_contains_operative_in_legend():
+    rows = [{"username": "alice", "2025": 100}, {"username": "bob", "2025": 50}]
+    with patch("ghsnitch.ui.IS_TTY", False):
+        output = render_stack(rows, ["2025"])
+    assert "alice" in output
+    assert "bob" in output
+
+
+def test_render_stack_zero_year_column_is_empty():
+    """A year with zero total contributions must produce no filled cells."""
+    rows = [{"username": "alice", "2024": 0, "2025": 500}]
+    # x_labels = reversed(["2025","2024"]) = ["2024","2025"] — 2024 is the left column.
+    with patch("ghsnitch.ui.IS_TTY", False):
+        with patch("os.get_terminal_size", return_value=os.terminal_size((80, 24))):
+            output = render_stack(rows, ["2025", "2024"])
+    y_axis_width = 7
+    col_width = 10  # deterministic for 80-wide terminal with 2 years
+    body_lines = [ln for ln in output.splitlines() if "┤" in ln or "│" in ln]
+    for ln in body_lines:
+        left_cell = ln[y_axis_width : y_axis_width + col_width]
+        assert "█" not in left_cell, f"Expected no blocks for zero year: {ln!r}"
+
+
+def test_render_stack_no_ansi_in_non_tty():
+    rows = [{"username": "alice", "2025": 100}]
+    with patch("ghsnitch.ui.IS_TTY", False):
+        output = render_stack(rows, ["2025"])
+    assert "\033[" not in output
+
+
+def test_render_stack_ansi_in_tty():
+    rows = [{"username": "alice", "2025": 100}]
+    with patch("ghsnitch.ui.IS_TTY", True):
+        with patch("os.get_terminal_size", return_value=os.terminal_size((80, 30))):
+            output = render_stack(rows, ["2025"])
+    assert "\033[" in output
+
+
+def test_render_stack_redact_shows_codenames():
+    rows = [{"username": "alice", "2025": 100}, {"username": "bob", "2025": 50}]
+    with patch("ghsnitch.ui.IS_TTY", False):
+        output = render_stack(
+            rows,
+            ["2025"],
+            redact_map={"alice": "Operative Alpha", "bob": "Operative Bravo"},
+        )
+    assert "Operative Alpha" in output
+    assert "Operative Bravo" in output
+    assert "alice" not in output
+    assert "bob" not in output
+
+
+def test_render_stack_all_zeros_does_not_crash():
+    rows = [{"username": "alice", "2025": 0}, {"username": "bob", "2025": 0}]
+    with patch("ghsnitch.ui.IS_TTY", False):
+        output = render_stack(rows, ["2025"])
+    assert output  # does not raise, returns something


### PR DESCRIPTION
## Summary

- Adds `--format stack` as a new output format rendering a vertical stacked bar chart in the terminal
- Each column is a year (chronological left→right); each bar is divided into colour-coded segments proportional to each operative's share of that year's total
- Implemented without additional dependencies — no library needed
- `--redact` supported: codenames appear in the legend
- `--percent` and `--totals` are not applicable and emit warnings

## Changes

| File | What changed |
|---|---|
| `src/ghsnitch/ui.py` | `render_stack()` function |
| `src/ghsnitch/cli.py` | `stack` added to `VALID_FORMATS`, wired to `render_stack` |
| `tests/test_ui.py` | 8 new unit tests |
| `tests/test_cli.py` | 3 CLI integration tests |
| `README.md` | `--format` row updated |
| `docs/manual/options.md` | `--format` row and config example updated |
| `docs/manual/usage.md` | New "Stacked Bar Chart" section |

## Test plan

- [x] \`make test\` — 274 tests pass
- [x] \`make lint\` — clean
- [x] \`make build\` — builds successfully
- [ ] Smoke test: \`gh-snitch --users alice,bob --years 3 --format stack\`
- [ ] Smoke test with \`--redact\`

Closes #86

🤖 Generated with [Claude Code](https://claude.ai/code)