### PR TITLE
feat: --export-config scaffolds TOML config from CLI args (#44)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -71,3 +71,7 @@ GITHUB_TOKEN=<token> uv run gh-snitch --users mrsixw --years 3 --no-update-check
 - **MANDATORY: Always create a GitHub issue before writing code or opening a PR.** This is a non-negotiable first step to confirm diagnosis and scope.
 - **MANDATORY: Before opening a PR, you MUST run `make test`, `make build`, and `make lint`** to ensure the code is functional, buildable, and compliant with project standards.
 - Link the PR to the issue in the PR body.
+
+## Branch Naming
+- **MANDATORY: Feature branches must follow the format `issue_<N>_<short_description>`**, e.g. `issue_44_export_config`, `issue_22_brief_mode`.
+- Use the `/start-issue` skill to create a correctly-named branch from an issue number. It checks out main, pulls, and creates the branch automatically.

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -1,0 +1,21 @@
+# Start Issue
+
+Start work on a GitHub issue by creating a correctly-named branch.
+
+## Usage
+
+```
+/start-issue <issue_number>
+```
+
+## Steps
+
+1. Fetch the issue title from GitHub using `mcp__github__issue_read` (method: `get`, owner: `mrsixw`, repo: `gh-snitch`, issue_number: `$ARGUMENTS`).
+2. Derive a short branch slug from the title: lowercase, replace spaces and non-alphanumeric characters with underscores, strip leading `feat:` / `fix:` / `chore:` prefixes, truncate to ~30 characters.
+3. Construct the branch name: `issue_<N>_<slug>` — e.g. `issue_44_export_config`.
+4. Run:
+   ```bash
+   git checkout main && git pull origin main
+   git checkout -b issue_<N>_<slug>
+   ```
+5. Confirm the branch name to the user and state that you are ready to implement the issue.

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -11,7 +11,7 @@ Start work on a GitHub issue by creating a correctly-named branch.
 ## Steps
 
 1. Fetch the issue title from GitHub using `mcp__github__issue_read` (method: `get`, owner: `mrsixw`, repo: `gh-snitch`, issue_number: `$ARGUMENTS`).
-2. Derive a short branch slug from the title: lowercase, replace spaces and non-alphanumeric characters with underscores, strip leading `feat:` / `fix:` / `chore:` prefixes, truncate to ~30 characters.
+2. Derive a short branch slug from the title: lowercase, replace spaces and non-alphanumeric characters with underscores, strip leading conventional commit prefixes (`feat:`, `fix:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, `build:`, `ci:`, `chore:`, `revert:`), truncate to ~30 characters.
 3. Construct the branch name: `issue_<N>_<slug>` — e.g. `issue_44_export_config`.
 4. Run:
    ```bash

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -73,3 +73,6 @@ GITHUB_TOKEN=<token> uv run gh-snitch --users mrsixw --years 3 --no-update-check
 - **MANDATORY: Always create a GitHub issue before writing code or opening a PR.** This is a non-negotiable first step to confirm diagnosis and scope.
 - **MANDATORY: Before opening a PR, you MUST run `make test`, `make build`, and `make lint`** to ensure the code is functional, buildable, and compliant with project standards.
 - Link the PR to the issue in the PR body.
+
+## Branch Naming
+- **MANDATORY: Feature branches must follow the format `issue_<N>_<short_description>`**, e.g. `issue_44_export_config`, `issue_22_brief_mode`.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ make build
 | `--reset-snapshot` | Clear the saved contribution snapshot and exit |
 | `--config` | Path to config file |
 | `--init-config` | Write default config and exit |
+| `--export-config` | Print TOML config scaffolded from current CLI args and exit (pipe to a file to save) |
 | `--show-config` | Print current config and exit |
 | `--no-update-check` | Skip update check |
 | `--version` | Show version |

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -22,6 +22,7 @@
 | `--reset-snapshot` | off | Clear the saved contribution snapshot and exit |
 | `--no-trend` | off | Hide the Trend column |
 | `--show-config` | off | Print current config and exit |
+| `--export-config` | off | Print a TOML config scaffolded from the current CLI arguments and exit. Reflects `--users`, `--years`, `--github-url` overrides. Does not require `GITHUB_TOKEN`. Pipe to a file to save: `gh-snitch --users alice,bob --export-config > config.toml` |
 | `--init-config` | off | Write default config file and exit |
 | `--no-update-check` | off | Skip checking for new releases |
 | `--version` | — | Show version and exit |

--- a/docs/manual/usage.md
+++ b/docs/manual/usage.md
@@ -124,6 +124,49 @@ gh-snitch --init-config
 
 Creates a default config at `~/.config/gh-snitch/config.toml`. Edit this file to add your operatives.
 
+## Exporting a Config from the Command Line
+
+Use `--export-config` to generate a ready-to-save TOML config from the operatives and options you specify on the command line. This is the reverse of the config-first flow — useful for bootstrapping a dossier from a one-liner and saving it for later.
+
+```bash
+gh-snitch --users alice,bob,carol --export-config
+```
+
+```toml
+[operatives]
+users = ["alice", "bob", "carol"]
+
+[surveillance]
+years = 3
+# period = "month"      # "week", "month", or "year" — overrides years when set
+# last_months = 6       # last 6 calendar months as separate columns
+# last_weeks = 8        # last 8 ISO weeks as separate columns
+
+[network]
+# github_url = "https://github.example.com"  # omit for github.com
+
+[display]
+# format = "table"
+# min_contributions = 0
+# totals = false
+# percent = false
+# rank_delta = true
+```
+
+CLI overrides are reflected in the output:
+
+```bash
+gh-snitch --users alice,bob --years 5 --github-url https://ghe.corp.com --export-config
+```
+
+Pipe directly to your config file to save it:
+
+```bash
+gh-snitch --users alice,bob,carol --export-config > ~/.config/gh-snitch/config.toml
+```
+
+`--export-config` does not require `GITHUB_TOKEN` — it exits before any API calls are made.
+
 ## Reviewing Your Config
 
 ```bash

--- a/src/ghsnitch/cli.py
+++ b/src/ghsnitch/cli.py
@@ -226,6 +226,13 @@ def _backup_config(path: Path):
     help="Add missing keys from template to existing config and exit.",
 )
 @click.option(
+    "--export-config",
+    "export_config",
+    is_flag=True,
+    default=False,
+    help="Print a TOML config scaffolded from current CLI arguments and exit.",
+)
+@click.option(
     "--github-url",
     default=None,
     help="GitHub base URL (default: https://github.com). For GitHub Enterprise Server.",
@@ -306,6 +313,7 @@ def gh_snitch(  # noqa: PLR0913
     show_config,
     init_config,
     update_config,
+    export_config,
     no_update_check,
     no_trend,
     min_contributions,
@@ -425,19 +433,6 @@ def gh_snitch(  # noqa: PLR0913
         user_hash = hashlib.sha256(user_key.encode()).hexdigest()[:12]
         context_id = f"u-{user_hash}"
 
-    if reset_snapshot:
-        clear_all_snapshots()
-        click.echo("🗑️  All snapshots cleared. Operative history wiped.", err=True)
-        return
-
-    if not SECRET_GITHUB_TOKEN:
-        click.echo(
-            "🚨 GITHUB_TOKEN not set. "
-            "Operatives cannot be surveilled without credentials.",
-            err=True,
-        )
-        sys.exit(1)
-
     if years is not None:
         cfg["years"] = years
     if period is not None:
@@ -458,6 +453,23 @@ def gh_snitch(  # noqa: PLR0913
         cfg["rank_delta"] = False
     if output_format is not None:
         cfg["output_format"] = output_format.lower()
+
+    if export_config:
+        click.echo(config_module.render_config(cfg))
+        return
+
+    if reset_snapshot:
+        clear_all_snapshots()
+        click.echo("🗑️  All snapshots cleared. Operative history wiped.", err=True)
+        return
+
+    if not SECRET_GITHUB_TOKEN:
+        click.echo(
+            "🚨 GITHUB_TOKEN not set. "
+            "Operatives cannot be surveilled without credentials.",
+            err=True,
+        )
+        sys.exit(1)
 
     active_format = cfg.get("output_format", "table")
 

--- a/src/ghsnitch/config.py
+++ b/src/ghsnitch/config.py
@@ -149,6 +149,54 @@ def load_config(config_path=None):
     return config
 
 
+def render_config(cfg: dict) -> str:
+    """Return a TOML config string scaffolded from a loaded cfg dict.
+
+    Active overrides (users, years, github_url) are written as live values;
+    optional keys are written as comments showing their current/default values.
+    The result is valid TOML that round-trips through load_config().
+    """
+    users = cfg.get("users", [])
+    users_toml = "[" + ", ".join(f'"{u}"' for u in users) + "]"
+
+    years = cfg.get("years", 3)
+
+    github_url = cfg.get("github_url", "https://github.com")
+    if github_url and github_url != "https://github.com":
+        network_url_line = f'github_url = "{github_url}"'
+    else:
+        network_url_line = (
+            '# github_url = "https://github.example.com"  # omit for github.com'
+        )
+
+    output_format = cfg.get("output_format", "table")
+    min_contributions = cfg.get("min_contributions", 0)
+    totals = str(cfg.get("totals", False)).lower()
+    percent = str(cfg.get("percent", False)).lower()
+    rank_delta = str(cfg.get("rank_delta", True)).lower()
+
+    return f"""\
+[operatives]
+users = {users_toml}
+
+[surveillance]
+years = {years}
+# period = "month"      # "week", "month", or "year" — overrides years when set
+# last_months = 6       # last 6 calendar months as separate columns
+# last_weeks = 8        # last 8 ISO weeks as separate columns
+
+[network]
+{network_url_line}
+
+[display]
+# format = "{output_format}"
+# min_contributions = {min_contributions}
+# totals = {totals}
+# percent = {percent}
+# rank_delta = {rank_delta}
+"""
+
+
 def generate_default_config(config_path=None):
     """Write default config template to disk. Returns the path used."""
     path = Path(config_path) if config_path else get_config_path()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1415,3 +1415,83 @@ def test_stack_format_redact_shows_codenames(runner, tmp_path, requests_mock):
     assert result.exit_code == 0
     assert "Operative Alpha" in result.output
     assert "alice" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# --export-config tests
+# ---------------------------------------------------------------------------
+
+
+def test_export_config_contains_users(runner, tmp_path):
+    cfg = tmp_path / "config.toml"
+    cfg.write_text("[operatives]\nusers = []\n")
+    result = runner.invoke(
+        gh_snitch,
+        [
+            "--config",
+            str(cfg),
+            "--users",
+            "alice,bob",
+            "--export-config",
+            "--no-update-check",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "alice" in result.output
+    assert "bob" in result.output
+
+
+def test_export_config_reflects_years(runner, tmp_path):
+    cfg = tmp_path / "config.toml"
+    cfg.write_text("[operatives]\nusers = []\n")
+    result = runner.invoke(
+        gh_snitch,
+        ["--config", str(cfg), "--users", "alice", "--years", "5", "--export-config"],
+    )
+    assert result.exit_code == 0
+    assert "years = 5" in result.output
+
+
+def test_export_config_no_token_required(runner, tmp_path):
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('[operatives]\nusers = ["alice"]\n')
+    with patch("ghsnitch.api.SECRET_GITHUB_TOKEN", None):
+        with patch("ghsnitch.cli.SECRET_GITHUB_TOKEN", None):
+            result = runner.invoke(
+                gh_snitch,
+                ["--config", str(cfg), "--export-config"],
+            )
+    assert result.exit_code == 0
+
+
+def test_export_config_reflects_github_url(runner, tmp_path):
+    cfg = tmp_path / "config.toml"
+    cfg.write_text("[operatives]\nusers = []\n")
+    result = runner.invoke(
+        gh_snitch,
+        [
+            "--config",
+            str(cfg),
+            "--users",
+            "alice",
+            "--github-url",
+            "https://ghe.corp.com",
+            "--export-config",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "ghe.corp.com" in result.output
+
+
+def test_export_config_round_trips(runner, tmp_path):
+    import tomllib
+
+    cfg = tmp_path / "config.toml"
+    cfg.write_text("[operatives]\nusers = []\n")
+    result = runner.invoke(
+        gh_snitch,
+        ["--config", str(cfg), "--users", "alice,bob", "--export-config"],
+    )
+    assert result.exit_code == 0
+    parsed = tomllib.loads(result.output)
+    assert parsed["operatives"]["users"] == ["alice", "bob"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,6 @@
-from ghsnitch.config import generate_default_config, load_config
+import tomllib
+
+from ghsnitch.config import generate_default_config, load_config, render_config
 
 
 def test_load_config_from_file(tmp_path):
@@ -165,3 +167,63 @@ def test_load_config_teams_alongside_operatives(tmp_path):
     cfg = load_config(str(config_file))
     assert cfg["users"] == ["carol"]
     assert cfg["teams"] == {"alpha": ["alice", "bob"]}
+
+
+# --- render_config tests ---
+
+
+def test_render_config_produces_valid_toml():
+    cfg = {"users": ["alice", "bob"], "years": 3, "github_url": "https://github.com"}
+    output = render_config(cfg)
+    parsed = tomllib.loads(output)
+    assert parsed["operatives"]["users"] == ["alice", "bob"]
+    assert parsed["surveillance"]["years"] == 3
+
+
+def test_render_config_users_in_output():
+    cfg = {
+        "users": ["alice", "bob", "carol"],
+        "years": 3,
+        "github_url": "https://github.com",
+    }
+    output = render_config(cfg)
+    assert "alice" in output
+    assert "bob" in output
+    assert "carol" in output
+
+
+def test_render_config_years_reflected():
+    cfg = {"users": ["alice"], "years": 5, "github_url": "https://github.com"}
+    output = render_config(cfg)
+    assert "years = 5" in output
+
+
+def test_render_config_default_github_url_is_commented():
+    cfg = {"users": [], "years": 3, "github_url": "https://github.com"}
+    output = render_config(cfg)
+    assert 'github_url = "https://github.com"' not in output.replace("# ", "X")
+    assert "github_url" in output
+
+
+def test_render_config_custom_github_url_is_active():
+    cfg = {"users": [], "years": 3, "github_url": "https://ghe.corp.com"}
+    output = render_config(cfg)
+    parsed = tomllib.loads(output)
+    assert parsed["network"]["github_url"] == "https://ghe.corp.com"
+
+
+def test_render_config_round_trips():
+    cfg = {"users": ["alice", "bob"], "years": 2, "github_url": "https://github.com"}
+    output = render_config(cfg)
+    import os
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+        f.write(output)
+        tmp = f.name
+    try:
+        loaded = load_config(tmp)
+        assert loaded["users"] == ["alice", "bob"]
+        assert loaded["years"] == 2
+    finally:
+        os.unlink(tmp)

--- a/uv.lock
+++ b/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "ghsnitch"
-version = "0.23.0"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "asciichartpy" },


### PR DESCRIPTION
Adds --export-config flag that prints a ready-to-save TOML config to
stdout, reflecting --users, --years, --github-url overrides. Exits
before the GITHUB_TOKEN check so no credentials are needed. Also adds
branch naming convention (issue_N_description) to CLAUDE.md, GEMINI.md,
and introduces the /start-issue repo skill.

https://claude.ai/code/session_013Z95UmTrCjHztPhB8zrDXP