### PR TITLE
fix: add TypeError to _read_version_cache() exception tuple (#92)

### DIFF
--- a/src/ghsnitch/updater.py
+++ b/src/ghsnitch/updater.py
@@ -25,7 +25,7 @@ def _read_version_cache():
         if age > _CACHE_TTL_SECONDS:
             return None
         return data.get("latest_version")
-    except (OSError, json.JSONDecodeError, KeyError, ValueError):
+    except (OSError, json.JSONDecodeError, KeyError, ValueError, TypeError):
         return None
 
 


### PR DESCRIPTION
## Summary
Add `TypeError` to the exception tuple in `_read_version_cache()` to catch errors when comparing naive and timezone-aware datetimes.

## Root cause
When a cached datetime is naive (no timezone) and gets compared with `datetime.now(timezone.utc)` (which is timezone-aware), Python raises `TypeError: can't subtract offset-naive and offset-aware datetimes`. This was not caught by the exception handler, causing an uncaught exception at the end of runs.

## Fix
Added `TypeError` to the exception tuple on line 28 of `src/ghsnitch/updater.py`.

## Validation
- Ran `make test` — all tests pass
- The fix is isolated to a single line change

## Before
Uncaught `TypeError: can't subtract offset-naive and offset-aware datetimes` at the end of runs when version cache contains naive datetimes.

## After
`TypeError` is caught alongside other expected exceptions, allowing graceful handling.

Fixes #92