### PR TITLE
fix: thread github_url through to hyperlinks for GHE support

### DIFF
--- a/src/ghsnitch/cli.py
+++ b/src/ghsnitch/cli.py
@@ -691,6 +691,7 @@ def gh_snitch(  # noqa: PLR0913
             rank_deltas=rank_deltas,
             ghost_usernames=ghost_usernames if not delta else None,
             redact_map=_redact,
+            github_url=operative_github_url,
         )
         click.echo(table)
 

--- a/src/ghsnitch/ui.py
+++ b/src/ghsnitch/ui.py
@@ -83,7 +83,9 @@ def make_coloured_hyperlink_cell(count, url, column_values):
     return str(count)
 
 
-def make_operative_cell(username, is_ghost=False, display_name=None):
+def make_operative_cell(
+    username, is_ghost=False, display_name=None, github_url="https://github.com"
+):
     """Return an operative name cell.
 
     When display_name is provided (redact mode) the cell is plain text with no
@@ -92,7 +94,7 @@ def make_operative_cell(username, is_ghost=False, display_name=None):
     if display_name is not None:
         ghost_mark = (" 👻" if IS_TTY else " [ghost]") if is_ghost else ""
         return display_name + ghost_mark
-    url = f"https://github.com/{username}"
+    url = f"{github_url.rstrip('/')}/{username}"
     link = make_hyperlink(url, username)
     if not is_ghost:
         return link
@@ -410,6 +412,7 @@ def render_table(
     rank_deltas=None,
     ghost_usernames=None,
     redact_map=None,
+    github_url="https://github.com",
 ):
     """Render contribution data as a formatted table string.
 
@@ -496,7 +499,12 @@ def render_table(
         is_ghost = ghost_usernames is not None and username in ghost_usernames
         display_name = redact_map.get(username) if redact_map else None
         cells.append(
-            make_operative_cell(username, is_ghost=is_ghost, display_name=display_name)
+            make_operative_cell(
+                username,
+                is_ghost=is_ghost,
+                display_name=display_name,
+                github_url=github_url,
+            )
         )
         if show_trend:
             current = row.get(year_labels[0], 0)
@@ -514,7 +522,7 @@ def render_table(
                 else:
                     cell = str(count)
             else:
-                contrib_url = f"https://github.com/{username}"
+                contrib_url = f"{github_url.rstrip('/')}/{username}"
                 cell = make_coloured_hyperlink_cell(
                     count, contrib_url, col_values[label]
                 )

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1098,3 +1098,43 @@ def test_render_stack_all_zeros_does_not_crash():
     with patch("ghsnitch.ui.IS_TTY", False):
         output = render_stack(rows, ["2025"])
     assert output  # does not raise, returns something
+
+
+# ---------------------------------------------------------------------------
+# GitHub Enterprise URL support (#90)
+# ---------------------------------------------------------------------------
+
+
+def test_make_operative_cell_ghe_url_in_hyperlink():
+    with patch("ghsnitch.ui.IS_TTY", True):
+        result = make_operative_cell("alice", github_url="https://github.example.com")
+    assert "https://github.example.com/alice" in result
+    assert "https://github.com" not in result
+
+
+def test_make_operative_cell_default_url_is_github_com():
+    with patch("ghsnitch.ui.IS_TTY", True):
+        result = make_operative_cell("alice")
+    assert "https://github.com/alice" in result
+
+
+def test_make_operative_cell_ghe_url_trailing_slash_normalised():
+    with patch("ghsnitch.ui.IS_TTY", True):
+        result = make_operative_cell("alice", github_url="https://github.example.com/")
+    assert "https://github.example.com/alice" in result
+    assert "//alice" not in result
+
+
+def test_render_table_ghe_url_in_cells():
+    rows = [{"username": "alice", "2025": 100}]
+    with patch("ghsnitch.ui.IS_TTY", True):
+        output = render_table(rows, ["2025"], github_url="https://github.example.com")
+    assert "https://github.example.com/alice" in output
+    assert "https://github.com" not in output
+
+
+def test_render_table_default_url_is_github_com():
+    rows = [{"username": "alice", "2025": 100}]
+    with patch("ghsnitch.ui.IS_TTY", True):
+        output = render_table(rows, ["2025"])
+    assert "https://github.com/alice" in output


### PR DESCRIPTION
## Summary

- `make_operative_cell` and `render_table` both hardcoded `https://github.com/` for OSC 8 terminal hyperlinks, ignoring `--github-url` / config
- Added `github_url` parameter (default `https://github.com`) to both functions
- `cli.py` now passes `operative_github_url` to `render_table` so all hyperlinks respect the configured GitHub instance
- 5 new tests covering GHE URLs in both `make_operative_cell` and `render_table`, including trailing-slash normalisation

## Test plan

- [ ] `make test` — all 279 tests pass
- [ ] `make lint` — clean
- [ ] Smoke test with `--github-url https://github.example.com` confirms operative name cells and contribution cells link to the correct host

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)