### PR TITLE
fix: stop --update-config from adding spurious display.users key

### DIFF
--- a/src/ghsnitch/config.py
+++ b/src/ghsnitch/config.py
@@ -217,6 +217,11 @@ def update_config(config_path=None):
             continue
         section_name = section_match.group(1)
 
+        # Stop at commented-out section headers so their keys don't attribute here.
+        commented_header = re.search(r"\n#\s*\[[\w.]+\]", section_block)
+        if commented_header:
+            section_block = section_block[: commented_header.start()]
+
         # Find all keys in this template section
         # Look for: # help text\n# key = value  OR  key = value
         # This regex catches:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-from ghsnitch.config import generate_default_config, load_config
+from ghsnitch.config import generate_default_config, load_config, update_config
 
 
 def test_load_config_from_file(tmp_path):
@@ -165,3 +165,11 @@ def test_load_config_teams_alongside_operatives(tmp_path):
     cfg = load_config(str(config_file))
     assert cfg["users"] == ["carol"]
     assert cfg["teams"] == {"alpha": ["alice", "bob"]}
+
+
+def test_update_config_does_not_add_display_users(tmp_path):
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("[display]\nmin_contributions = 10\n")
+    added = update_config(str(config_file))
+    assert "display.users" not in added
+    assert "display.users" not in config_file.read_text()


### PR DESCRIPTION
Fixes #91.

`update_config()` split `_DEFAULT_CONFIG_TEMPLATE` on real `[section]`
lines, so the commented-out example block at the end of `[display]`
(`# [teams.backend]\n# users = ...`) stayed attached to the `[display]`
section. The key-detection regex then matched `# users = ...` and
attributed a `display.users` key that was injected on every update.

Fix is in `src/ghsnitch/config.py`: when iterating template sections,
trim each section block at the first commented section header before
scanning for keys. Added a `test_update_config_does_not_add_display_users`
regression test in `tests/test_config.py`. All 280 tests pass.