### PR TITLE
fix: ignore relative $XDG_*_HOME values per spec

### DIFF
--- a/src/ghsnitch/xdg.py
+++ b/src/ghsnitch/xdg.py
@@ -2,39 +2,51 @@ import os
 from pathlib import Path
 
 
+def _xdg_override(env_var: str) -> Path | None:
+    """Return the env var value as a Path only if it is set to an absolute path.
+
+    The XDG Base Directory Specification requires that $XDG_*_HOME values be
+    absolute paths; relative values must be ignored and the default used instead.
+    """
+    val = os.getenv(env_var)
+    if val and Path(val).is_absolute():
+        return Path(val)
+    return None
+
+
 def get_config_dir() -> Path:
     """Return the XDG-compliant config directory for gh-snitch.
 
-    Uses $XDG_CONFIG_HOME if set, otherwise ~/.config/gh-snitch.
+    Uses $XDG_CONFIG_HOME if set to an absolute path, otherwise ~/.config/gh-snitch.
     Appropriate for user configuration files.
     """
-    xdg_config = os.getenv("XDG_CONFIG_HOME")
-    if xdg_config:
-        return Path(xdg_config) / "gh-snitch"
+    override = _xdg_override("XDG_CONFIG_HOME")
+    if override:
+        return override / "gh-snitch"
     return Path.home() / ".config" / "gh-snitch"
 
 
 def get_cache_dir() -> Path:
     """Return the XDG-compliant cache directory for gh-snitch.
 
-    Uses $XDG_CACHE_HOME if set, otherwise ~/.cache/gh-snitch.
+    Uses $XDG_CACHE_HOME if set to an absolute path, otherwise ~/.cache/gh-snitch.
     Appropriate for ephemeral data: update-check results, contribution snapshots.
     """
-    xdg_cache = os.getenv("XDG_CACHE_HOME")
-    if xdg_cache:
-        return Path(xdg_cache) / "gh-snitch"
+    override = _xdg_override("XDG_CACHE_HOME")
+    if override:
+        return override / "gh-snitch"
     return Path.home() / ".cache" / "gh-snitch"
 
 
 def get_log_dir() -> Path:
     """Return the XDG-compliant log/state directory for gh-snitch.
 
-    Uses $XDG_STATE_HOME if set, otherwise ~/.local/state/gh-snitch.
+    Uses $XDG_STATE_HOME if set to an absolute path, otherwise ~/.local/state/gh-snitch.
     Appropriate for persistent operational data: logs, history.
     """
-    xdg_state = os.getenv("XDG_STATE_HOME")
-    if xdg_state:
-        return Path(xdg_state) / "gh-snitch"
+    override = _xdg_override("XDG_STATE_HOME")
+    if override:
+        return override / "gh-snitch"
     return Path.home() / ".local" / "state" / "gh-snitch"
 
 

--- a/tests/test_xdg.py
+++ b/tests/test_xdg.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+from ghsnitch.xdg import get_cache_dir, get_config_dir, get_log_dir
+
+
+def test_get_config_dir_absolute_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    assert get_config_dir() == tmp_path / "gh-snitch"
+
+
+def test_get_config_dir_relative_ignored(monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", "relative/path")
+    result = get_config_dir()
+    assert result == Path.home() / ".config" / "gh-snitch"
+
+
+def test_get_config_dir_empty_ignored(monkeypatch):
+    monkeypatch.setenv("XDG_CONFIG_HOME", "")
+    result = get_config_dir()
+    assert result == Path.home() / ".config" / "gh-snitch"
+
+
+def test_get_config_dir_unset_uses_default(monkeypatch):
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    assert get_config_dir() == Path.home() / ".config" / "gh-snitch"
+
+
+def test_get_cache_dir_absolute_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    assert get_cache_dir() == tmp_path / "gh-snitch"
+
+
+def test_get_cache_dir_relative_ignored(monkeypatch):
+    monkeypatch.setenv("XDG_CACHE_HOME", ".cache")
+    result = get_cache_dir()
+    assert result == Path.home() / ".cache" / "gh-snitch"
+
+
+def test_get_cache_dir_empty_ignored(monkeypatch):
+    monkeypatch.setenv("XDG_CACHE_HOME", "")
+    result = get_cache_dir()
+    assert result == Path.home() / ".cache" / "gh-snitch"
+
+
+def test_get_cache_dir_unset_uses_default(monkeypatch):
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    assert get_cache_dir() == Path.home() / ".cache" / "gh-snitch"
+
+
+def test_get_log_dir_absolute_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    assert get_log_dir() == tmp_path / "gh-snitch"
+
+
+def test_get_log_dir_relative_ignored(monkeypatch):
+    monkeypatch.setenv("XDG_STATE_HOME", "state")
+    result = get_log_dir()
+    assert result == Path.home() / ".local" / "state" / "gh-snitch"
+
+
+def test_get_log_dir_empty_ignored(monkeypatch):
+    monkeypatch.setenv("XDG_STATE_HOME", "")
+    result = get_log_dir()
+    assert result == Path.home() / ".local" / "state" / "gh-snitch"
+
+
+def test_get_log_dir_unset_uses_default(monkeypatch):
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    assert get_log_dir() == Path.home() / ".local" / "state" / "gh-snitch"


### PR DESCRIPTION
## Summary

- The XDG Base Directory Specification requires `$XDG_*_HOME` values to be **absolute paths**; relative values must be ignored and the conventional default used instead
- All three helpers in `xdg.py` accepted relative values, which could cause config, cache, and log files to land in a CWD-relative location that changes between invocations
- Adds `_xdg_override()` internal helper that validates absoluteness before returning the env var as a `Path`; all three `get_*_dir()` helpers use it
- Adds `test_xdg.py` with 12 tests covering absolute override, relative ignored, empty ignored, and unset default for all three helpers

## Test plan

- [x] `make test` — 286 passed (+12 new tests)
- [x] `make lint` — clean

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)