### PR TITLE
fix: handle pre-release version strings in _parse_version_tuple

### DIFF
--- a/src/ghsnitch/updater.py
+++ b/src/ghsnitch/updater.py
@@ -1,4 +1,5 @@
 import json
+import re
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
@@ -69,7 +70,13 @@ def get_latest_version():
 
 def _parse_version_tuple(version_str):
     try:
-        return tuple(int(x) for x in version_str.split("."))
+        parts = []
+        for segment in version_str.split("."):
+            m = re.match(r"\d+", segment)
+            if not m:
+                break
+            parts.append(int(m.group()))
+        return tuple(parts)
     except (ValueError, AttributeError):
         return ()
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,44 @@
+from ghsnitch.updater import _parse_version_tuple
+
+
+def test_parse_version_tuple_normal():
+    assert _parse_version_tuple("1.2.3") == (1, 2, 3)
+
+
+def test_parse_version_tuple_single():
+    assert _parse_version_tuple("42") == (42,)
+
+
+def test_parse_version_tuple_empty_string():
+    assert _parse_version_tuple("") == ()
+
+
+def test_parse_version_tuple_invalid():
+    assert _parse_version_tuple("not-a-version") == ()
+
+
+def test_parse_version_tuple_prerelease_alpha():
+    assert _parse_version_tuple("1.0.0a1") == (1, 0, 0)
+
+
+def test_parse_version_tuple_prerelease_dash():
+    assert _parse_version_tuple("1.0.0-beta") == (1, 0, 0)
+
+
+def test_parse_version_tuple_prerelease_rc():
+    assert _parse_version_tuple("2.1.0rc3") == (2, 1, 0)
+
+
+def test_parse_version_tuple_prerelease_compares_correctly():
+    # Pre-release 1.0.0a1 should parse as (1, 0, 0), not () —
+    # so it compares equal to the release, not spuriously less than it.
+    pre = _parse_version_tuple("1.0.0a1")
+    release = _parse_version_tuple("1.0.0")
+    assert pre == release
+
+
+def test_parse_version_tuple_prerelease_does_not_trigger_false_update():
+    # Installed pre-release must not compare as less than the same release.
+    installed = _parse_version_tuple("0.25.0a1")
+    latest = _parse_version_tuple("0.25.0")
+    assert not (latest > installed)


### PR DESCRIPTION
## Summary

- `_parse_version_tuple` used `int(x) for x in version_str.split(".")` which raises `ValueError` for pre-release segments like `"0a1"`, `"0rc3"`, or `"0-beta"`
- The `except` clause returned `()`, which compares less than any non-empty tuple — so any pre-release installed version triggered a false update notice on every run
- Fixed by using `re.match(r"\d+", segment)` to extract the leading numeric portion, stopping at the first segment with no leading digits: `"1.0.0a1"` → `(1, 0, 0)`
- Adds `test_updater.py` with 9 tests covering normal versions, pre-release variants, and the false-update regression case

## Test plan

- [x] `make test` — 283 passed (+9 new tests)
- [x] `make lint` — clean

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)