### PR TITLE
fix: make setup_logging() idempotent by replacing existing handlers

### DIFF
--- a/src/ghsnitch/logger.py
+++ b/src/ghsnitch/logger.py
@@ -23,6 +23,9 @@ def setup_logging():
         handler.setLevel(logging.DEBUG)
         handler.setFormatter(logging.Formatter(_FMT, datefmt=_DATE_FMT))
         logger = logging.getLogger("ghsnitch")
+        for h in logger.handlers[:]:
+            h.close()
+            logger.removeHandler(h)
         logger.setLevel(logging.DEBUG)
         logger.addHandler(handler)
         logger.propagate = False

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -85,3 +85,17 @@ def test_setup_logging_creates_log_dir(tmp_path):
 
     logging.getLogger("ghsnitch").info("hello")
     assert log_file.exists()
+
+
+def test_setup_logging_replaces_existing_handlers(tmp_path):
+    log_file = tmp_path / "run.log"
+    with (
+        patch("ghsnitch.logger.LOG_DIR", tmp_path),
+        patch("ghsnitch.logger._LOG_FILE", log_file),
+    ):
+        from ghsnitch.logger import setup_logging
+
+        setup_logging()
+        setup_logging()
+
+    assert len(logging.getLogger("ghsnitch").handlers) == 1


### PR DESCRIPTION
## Summary

- `setup_logging()` called `logger.addHandler()` unconditionally, stacking a new `FileHandler` on every call without removing the previous one
- In tests that invoke the CLI multiple times via `CliRunner`, this accumulated handlers and leaked file descriptors; log lines were also written multiple times per entry
- Fixed by closing and removing all existing handlers before attaching the new one, making repeated calls safe
- Adds `test_setup_logging_replaces_existing_handlers` asserting exactly one handler after two consecutive calls

## Test plan

- [x] `make test` — 275 passed (+1 new test)
- [x] `make lint` — clean

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)