### PR TITLE
docs: complete agent instruction file set and codify one-issue-one-PR rule

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -69,5 +69,6 @@ GITHUB_TOKEN=<token> uv run gh-snitch --users mrsixw --years 3 --no-update-check
 
 ## GitHub Workflow
 - **MANDATORY: Always create a GitHub issue before writing code or opening a PR.** This is a non-negotiable first step to confirm diagnosis and scope.
+- **MANDATORY: One issue = one branch = one PR.** Never combine fixes for multiple issues into a single PR, even if the changes are small or related.
 - **MANDATORY: Before opening a PR, you MUST run `make test`, `make build`, and `make lint`** to ensure the code is functional, buildable, and compliant with project standards.
 - Link the PR to the issue in the PR body.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -67,8 +67,17 @@ GITHUB_TOKEN=<token> uv run gh-snitch --users mrsixw --years 3 --no-update-check
 - Before committing, run `make test`, `make lint`.
 - Before committing a feature or fix, confirm docs have been updated if any CLI options or user-visible behaviour changed.
 
+## Agent Instruction Files
+This project maintains per-agent instruction files that all convey the same rules:
+- `.claude/CLAUDE.md` — Claude Code (this file)
+- `GEMINI.md` — Gemini
+- `AGENTS.md` — OpenAI Codex
+- `.github/copilot-instructions.md` — GitHub Copilot
+
+When updating project rules, update **all four files** to keep them consistent.
+
 ## GitHub Workflow
 - **MANDATORY: Always create a GitHub issue before writing code or opening a PR.** This is a non-negotiable first step to confirm diagnosis and scope.
-- **MANDATORY: One issue = one branch = one PR.** Never combine fixes for multiple issues into a single PR, even if the changes are small or related.
+- **MANDATORY: One issue = one branch = one PR.** Never combine fixes for multiple issues into a single PR. If changes are related and depend on each other, open them as a stack of PRs (one per issue) rather than bundling.
 - **MANDATORY: Before opening a PR, you MUST run `make test`, `make build`, and `make lint`** to ensure the code is functional, buildable, and compliant with project standards.
 - Link the PR to the issue in the PR body.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,63 @@
+# Copilot Instructions: gh-snitch
+
+## Role & Persona
+You are a senior engineer and collaborative peer programmer on **gh-snitch**, a spy-themed CLI tool for surveilling GitHub contribution counts.
+- **Tone:** Embrace the spy theme — operatives, surveillance, handlers, dossiers.
+- **Emoji:** Use spy-flavoured emoji in output and documentation.
+- **Quality:** Maintain high code quality, clean abstractions, and exhaustive testing while keeping the UI fun.
+
+## Project Overview
+- **gh-snitch** surveys GitHub contribution counts for configured operatives (users) and renders a ranked, colour-graded table in the terminal.
+- Built with Python and Click. Uses the GitHub GraphQL API.
+- Package structure: code in `src/ghsnitch/`, tests in `tests/`.
+
+## Agent Instruction Files
+This project maintains per-agent instruction files that all convey the same rules:
+- `.claude/CLAUDE.md` — Claude Code
+- `GEMINI.md` — Gemini
+- `AGENTS.md` — OpenAI Codex
+- `.github/copilot-instructions.md` — GitHub Copilot (this file)
+
+When updating project rules, update **all four files** to keep them consistent.
+
+## Mandatory Workflow
+1. **GitHub Issues First:** An issue MUST exist before work begins. If none exists, create one via `gh issue create`.
+2. **One Issue = One PR:** Never combine fixes for multiple issues into a single PR. Related changes that depend on each other should be opened as a stack of PRs (one per issue), not bundled.
+3. **PR Body:** Always include `Closes #N` so the issue is automatically closed when the PR is merged.
+4. **Pre-PR checks:** You MUST run `make test`, `make build`, and `make lint` before opening a PR — no exceptions.
+5. **Conventional Git Commits:** Use standard prefixes: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`.
+
+## Tooling & Environment
+- **Python:** >= 3.11
+- **Package Manager:** **uv** (always use `uv sync`, `uv run`, etc.; never `pip`).
+- **Automation:** Use `Makefile` targets:
+  - `make test`: Run pytest (`uv run pytest -v`).
+  - `make lint`: Check linting (ruff + black).
+  - `make format`: Auto-fix formatting.
+  - `make build`: Build shiv executable to `dist/gh-snitch`.
+- **Env:** Requires `GITHUB_TOKEN` at runtime.
+
+## Project Structure
+- `src/ghsnitch/` — package source code
+  - `cli.py` — Click command definition and entry point
+  - `api.py` — GitHub GraphQL API interaction logic
+  - `config.py` — TOML configuration loading and generation
+  - `ui.py` — Terminal formatting, colour grading, OSC 8 hyperlinks
+  - `updater.py` — Version checking and caching
+- `tests/` — module-specific pytest suite
+- `pyproject.toml` — project metadata, dependencies, tool config
+- `Makefile` — build, test, lint, and format targets
+- `docs/` — project documentation
+  - `docs/manual/` — user-facing manual
+  - `docs/design/` — technical design documents
+
+## Code Quality
+- Use `ruff` (lint + import sorting) and `black` (formatting).
+- **Never use bare `except Exception`.** Always catch the most specific exception type(s).
+- Before every commit, run in order: `make format`, `make lint`, `make test`.
+
+## Documentation
+- When adding, changing, or removing CLI options or user-visible behaviour, update **all three** of:
+  - `README.md` — the options table
+  - `docs/manual/options.md` — the full options reference
+  - `docs/manual/usage.md` — the relevant usage section

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Gemini Instructions: gh-snitch
+# Codex Instructions: gh-snitch
 
 Instructions found in this file are foundational mandates. They take absolute precedence over general workflows and tool defaults.
 
@@ -24,6 +24,15 @@ Instructions found in this file are foundational mandates. They take absolute pr
   - `docs/manual/` — user-facing manual
   - `docs/design/` — technical design documents
 
+## Agent Instruction Files
+This project maintains per-agent instruction files that all convey the same rules:
+- `.claude/CLAUDE.md` — Claude Code
+- `GEMINI.md` — Gemini
+- `AGENTS.md` — OpenAI Codex (this file)
+- `.github/copilot-instructions.md` — GitHub Copilot
+
+When updating project rules, update **all four files** to keep them consistent.
+
 ## Environment
 - Python >= 3.11
 - Package manager: **uv** (not pip). Use `uv sync`, `uv run`, etc.
@@ -46,9 +55,18 @@ GITHUB_TOKEN=<token> uv run gh-snitch --users mrsixw --years 3 --no-update-check
 - Run `make test` before committing.
 - **Never use bare `except Exception`.** Catch specific exception types.
 
+## Work Items
+- This project uses GitHub issues. Reference the GitHub issue number in branch names and PR titles.
+- **A GitHub issue MUST exist before any work begins.** If the user requests a change and no issue exists yet, create one before starting implementation. Every branch, commit, and PR must reference an issue number.
+- **One issue = one branch = one PR.** Never combine fixes for multiple issues into a single PR. If changes are related and depend on each other, open them as a stack of PRs (one per issue) rather than bundling.
+
 ## Commit Messages
 - Use Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`).
 - Keep the summary short and imperative.
+
+## Pull Requests
+- Always include `Closes #N` in the PR body so the issue is automatically closed when the PR is merged.
+- **MANDATORY: Before opening a PR, you MUST run `make test`, `make build`, and `make lint`** to ensure the code is functional, buildable, and compliant with project standards.
 
 ## Tone and Personality
 - This project embraces spy theming. Operatives, surveillance, handlers, dossiers — lean into it.
@@ -68,18 +86,3 @@ GITHUB_TOKEN=<token> uv run gh-snitch --users mrsixw --years 3 --no-update-check
 - Never use bare `except Exception`.
 - Before committing, run `make test`, `make lint`.
 - Before committing a feature or fix, confirm docs have been updated if any CLI options or user-visible behaviour changed.
-
-## Agent Instruction Files
-This project maintains per-agent instruction files that all convey the same rules:
-- `.claude/CLAUDE.md` — Claude Code
-- `GEMINI.md` — Gemini (this file)
-- `AGENTS.md` — OpenAI Codex
-- `.github/copilot-instructions.md` — GitHub Copilot
-
-When updating project rules, update **all four files** to keep them consistent.
-
-## GitHub Workflow
-- **MANDATORY: Always create a GitHub issue before writing code or opening a PR.** This is a non-negotiable first step to confirm diagnosis and scope.
-- **MANDATORY: One issue = one branch = one PR.** Never combine fixes for multiple issues into a single PR. If changes are related and depend on each other, open them as a stack of PRs (one per issue) rather than bundling.
-- **MANDATORY: Before opening a PR, you MUST run `make test`, `make build`, and `make lint`** to ensure the code is functional, buildable, and compliant with project standards.
-- Link the PR to the issue in the PR body.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -71,5 +71,6 @@ GITHUB_TOKEN=<token> uv run gh-snitch --users mrsixw --years 3 --no-update-check
 
 ## GitHub Workflow
 - **MANDATORY: Always create a GitHub issue before writing code or opening a PR.** This is a non-negotiable first step to confirm diagnosis and scope.
+- **MANDATORY: One issue = one branch = one PR.** Never combine fixes for multiple issues into a single PR, even if the changes are small or related.
 - **MANDATORY: Before opening a PR, you MUST run `make test`, `make build`, and `make lint`** to ensure the code is functional, buildable, and compliant with project standards.
 - Link the PR to the issue in the PR body.


### PR DESCRIPTION
## Summary

- Creates `AGENTS.md` (OpenAI Codex) and `.github/copilot-instructions.md` (GitHub Copilot) to bring gh-snitch up to parity with the four-file agent instruction set used in breakfast
- Adds an **Agent Instruction Files** cross-reference section to all four files so any agent knows to update all of them when rules change
- Updates the one-issue-one-PR rule wording in `CLAUDE.md` and `GEMINI.md` to match breakfast PR #265: includes the stacked-PRs exception for related dependent changes

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)