### PR TITLE
fix: account for wide Unicode chars in column width measurement

### DIFF
--- a/src/ghsnitch/ui.py
+++ b/src/ghsnitch/ui.py
@@ -4,6 +4,7 @@ import json as _json
 import os
 import re
 import sys
+import unicodedata
 from datetime import datetime
 
 import asciichartpy as ac
@@ -12,15 +13,27 @@ from tabulate import tabulate
 
 IS_TTY = sys.stdout.isatty() and not os.getenv("NO_COLOR")
 
-# Patch tabulate to strip OSC 8 hyperlink sequences when measuring column widths.
-# Without this, tabulate counts invisible escape bytes as visible characters,
-# causing grossly over-wide columns and broken alignment.
+# Patch tabulate to correctly measure column widths when cells contain OSC 8
+# hyperlink sequences or wide Unicode characters (e.g. emoji).
+#
+# Without this patch two things go wrong:
+#   1. Tabulate counts invisible OSC 8 escape bytes as visible characters,
+#      producing grossly over-wide columns.
+#   2. Without the optional `wcwidth` package installed, tabulate falls back to
+#      len(), which counts wide characters (East Asian Width W/F, which includes
+#      emoji like 👻) as 1 column even though terminals render them as 2. This
+#      causes a 1-column misalignment on every row that contains such a character.
+#
+# The fix strips OSC 8 sequences and then uses unicodedata (stdlib) to tally
+# visual width, counting W/F characters as 2 and everything else as 1.
 _OSC8_RE = re.compile(r"\x1b\]8;[^;]*;[^\x1b]*\x1b\\")
-_orig_visible_width = _tabulate_module._visible_width
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 
 
 def _patched_visible_width(s):
-    return _orig_visible_width(_OSC8_RE.sub("", str(s)))
+    s = _OSC8_RE.sub("", str(s))
+    s = _ANSI_RE.sub("", s)
+    return sum(2 if unicodedata.east_asian_width(c) in ("W", "F") else 1 for c in s)
 
 
 _tabulate_module._visible_width = _patched_visible_width

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -839,6 +839,36 @@ def test_render_table_ghost_indicator_tty():
     assert "👻" in output
 
 
+def test_render_table_ghost_emoji_column_alignment_tty():
+    # 👻 is a wide Unicode character (East Asian Width = W, 2 terminal columns).
+    # Without explicit wide-char accounting, tabulate undercounts it by 1 and
+    # pads ghost rows with one too few spaces, misaligning subsequent columns.
+    # Verify the separator width matches every data row's content width.
+    rows = [
+        {"username": "alice", "2025": 0},
+        {"username": "bob", "2025": 50},
+    ]
+    import re
+
+    def strip_escapes(s):
+        s = re.sub(r"\x1b\][^\x1b]*\x1b\\", "", s)  # OSC 8
+        s = re.sub(r"\x1b\[[0-9;]*[A-Za-z]", "", s)  # ANSI
+        return s
+
+    with patch("ghsnitch.ui.IS_TTY", True):
+        output = render_table(rows, ["2025"], ghost_usernames={"alice"})
+
+    lines = [strip_escapes(ln) for ln in output.splitlines() if ln.strip()]
+    sep_line = next(ln for ln in lines if ln.startswith("-"))
+    sep_width = len(sep_line)
+    for line in lines:
+        if line.startswith("-"):
+            continue
+        # Each data/header line must be no wider than the separator (allowing
+        # for trailing spaces that some tabulate versions omit).
+        assert len(line) <= sep_width + 1, f"misaligned line: {line!r}"
+
+
 def test_render_table_no_ghost_when_not_provided():
     rows = [{"username": "alice", "2025": 0}]
     with patch("ghsnitch.ui.IS_TTY", False):


### PR DESCRIPTION
## Summary

- The 👻 emoji (East Asian Width = `W`) occupies **2 terminal columns** but `len()` counts it as 1
- Without `wcwidth` installed, tabulate fell back to `len()`, so ghost-operative rows were 1 column too wide, misaligning every column after Operative
- Replaces `_patched_visible_width` to strip both OSC 8 hyperlinks and ANSI codes, then uses `unicodedata.east_asian_width` (stdlib, no new dependency) to count `W`/`F` characters as 2 columns
- Adds `test_render_table_ghost_emoji_column_alignment_tty` to catch regressions

## Test plan

- [x] `make test` — 275 passed (+1 new test)
- [x] `make lint` — clean
- [x] Visual check: ghost row and non-ghost rows align correctly after stripping escapes

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)